### PR TITLE
Fire and forget Target.closeTarget

### DIFF
--- a/lib/PuppeteerSharp/Connection.cs
+++ b/lib/PuppeteerSharp/Connection.cs
@@ -52,7 +52,7 @@ namespace PuppeteerSharp
 
         #region Public Methods
 
-        public async Task<dynamic> SendAsync(string method, dynamic args = null)
+        public async Task<dynamic> SendAsync(string method, dynamic args = null, bool waitForResponse = true)
         {
             var id = ++_lastId;
             var message = JsonConvert.SerializeObject(new Dictionary<string, object>(){
@@ -74,7 +74,14 @@ namespace PuppeteerSharp
                 _closeMessageSent = true;
             }
 
-            return await _responses[id].Task;
+            if (waitForResponse)
+            {
+                return await _responses[id].Task;
+            }
+            else
+            {
+                return Task.CompletedTask;
+            }
         }
 
         private void QueueId(int id)

--- a/lib/PuppeteerSharp/Connection.cs
+++ b/lib/PuppeteerSharp/Connection.cs
@@ -52,7 +52,7 @@ namespace PuppeteerSharp
 
         #region Public Methods
 
-        public async Task<dynamic> SendAsync(string method, dynamic args = null, bool waitForResponse = true)
+        public async Task<dynamic> SendAsync(string method, dynamic args = null)
         {
             var id = ++_lastId;
             var message = JsonConvert.SerializeObject(new Dictionary<string, object>(){
@@ -74,14 +74,7 @@ namespace PuppeteerSharp
                 _closeMessageSent = true;
             }
 
-            if (waitForResponse)
-            {
-                return await _responses[id].Task;
-            }
-            else
-            {
-                return Task.CompletedTask;
-            }
+            return await _responses[id].Task;
         }
 
         private void QueueId(int id)

--- a/lib/PuppeteerSharp/Page.cs
+++ b/lib/PuppeteerSharp/Page.cs
@@ -477,7 +477,7 @@ namespace PuppeteerSharp
                 });
             }
 
-            return null;
+            return Task.CompletedTask;
         }
 
         public Task<dynamic> EvaluateExpressionAsync(string script)

--- a/lib/PuppeteerSharp/Page.cs
+++ b/lib/PuppeteerSharp/Page.cs
@@ -474,7 +474,7 @@ namespace PuppeteerSharp
                 await _client.Connection.SendAsync("Target.closeTarget", new
                 {
                     targetId = _target.TargetId
-                });
+                }, false);
             }
         }
 

--- a/lib/PuppeteerSharp/Page.cs
+++ b/lib/PuppeteerSharp/Page.cs
@@ -467,15 +467,17 @@ namespace PuppeteerSharp
 
         public Task<string> GetTitleAsync() => MainFrame.GetTitleAsync();
 
-        public async Task CloseAsync()
+        public Task CloseAsync()
         {
             if (!(_client?.Connection?.IsClosed ?? true))
             {
-                await _client.Connection.SendAsync("Target.closeTarget", new
+                return _client.Connection.SendAsync("Target.closeTarget", new
                 {
                     targetId = _target.TargetId
-                }, false);
+                });
             }
+
+            return null;
         }
 
         public Task<dynamic> EvaluateExpressionAsync(string script)
@@ -780,7 +782,7 @@ namespace PuppeteerSharp
         #endregion
 
         #region IDisposable
-        public void Dispose() => CloseAsync().GetAwaiter().GetResult();
+        public void Dispose() => CloseAsync();
         #endregion
     }
 }


### PR DESCRIPTION
In some scenarios `GetAwaiter().Result` might produce some deadlocks, there are many [post about this](https://blog.stephencleary.com/2012/07/dont-block-on-async-code.html).
I was never a fan of GetAwaiters because there was something in my mind saying "hey this might break", but we were forced to use `GetAwaiter` because we don't have a DisposableAsync.

So we fell into some deadlocks in console apps. 
When we lock the execution here:
https://github.com/kblok/puppeteer-sharp/blob/master/lib/PuppeteerSharp/Page.cs#L783

There we are preventing the `ReceiveAsync` method from getting the result the same `CloseAsync`, through `target.closeTarget` is waiting for.

https://github.com/kblok/puppeteer-sharp/blob/master/lib/PuppeteerSharp/Connection.cs#L134

I'm fixing this by calling that close as a trigger and forget. I don't think that all `SendAsync` that are not expecting a value should be a trigger and forget call, because is good to know if the command was successfully executed. But a close is a close, we want to get out of there as soon as possible.

closes #122 
