### PR TITLE
Process exit improvements

### DIFF
--- a/lib/PuppeteerSharp.Tests/Issues/Issue0128.cs
+++ b/lib/PuppeteerSharp.Tests/Issues/Issue0128.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace PuppeteerSharp.Tests.Issues
+{
+    [Collection("PuppeteerLoaderFixture collection")]
+    public class Issue0128
+    {
+        [Fact]
+        public async Task LauncherShouldFailGracefully()
+        {
+            await Assert.ThrowsAsync<ChromeProcessException>(async () =>
+            {
+                var options = TestConstants.DefaultBrowserOptions();
+                options.Args = new[] { "-remote-debugging-port=-2" };
+                await PuppeteerSharp.Puppeteer.LaunchAsync(options, TestConstants.ChromiumRevision);
+            });
+        }
+    }
+}

--- a/lib/PuppeteerSharp/ChromeProcessException.cs
+++ b/lib/PuppeteerSharp/ChromeProcessException.cs
@@ -1,9 +1,16 @@
-﻿namespace PuppeteerSharp
+﻿using System;
+
+namespace PuppeteerSharp
 {
     public class ChromeProcessException : PuppeteerException
     {
         public ChromeProcessException(string message) : base(message)
         {
+        }
+
+        public ChromeProcessException(string message, Exception innerException) : base(message, innerException)
+        {
+
         }
     }
 }

--- a/lib/PuppeteerSharp/Launcher.cs
+++ b/lib/PuppeteerSharp/Launcher.cs
@@ -153,10 +153,10 @@ namespace PuppeteerSharp
                 var keepAliveInterval = options.KeepAliveInterval;
 
                 _connection = await Connection.Create(browserWSEndpoint, connectionDelay, keepAliveInterval);
+                _processLoaded = true;
 
                 if (options.LogProcess)
                 {
-                    _processLoaded = true;
                     Console.WriteLine($"PROCESS COUNT: {Interlocked.Increment(ref _processCount)}");
                 }
 
@@ -169,7 +169,7 @@ namespace PuppeteerSharp
             }
 
         }
-        
+
         public async Task TryDeleteUserDataDir(int times = 10, TimeSpan? delay = null)
         {
             if (!IsChromeClosed)
@@ -226,7 +226,7 @@ namespace PuppeteerSharp
         #endregion
 
         #region Private methods
-        
+
         private Task<string> WaitForEndpoint(Process chromeProcess, int timeout, bool dumpio)
         {
             var taskWrapper = new TaskCompletionSource<string>();

--- a/lib/PuppeteerSharp/Launcher.cs
+++ b/lib/PuppeteerSharp/Launcher.cs
@@ -46,7 +46,7 @@ namespace PuppeteerSharp
         private LaunchOptions _options;
         private TaskCompletionSource<bool> _waitForChromeToClose;
         private static int _processCount = 0;
-
+        private bool _processLoaded;
         private const string UserDataDirArgument = "--user-data-dir";
         #endregion
 
@@ -156,6 +156,7 @@ namespace PuppeteerSharp
 
                 if (options.LogProcess)
                 {
+                    _processLoaded = true;
                     Console.WriteLine($"PROCESS COUNT: {Interlocked.Increment(ref _processCount)}");
                 }
 
@@ -164,7 +165,7 @@ namespace PuppeteerSharp
             catch (Exception ex)
             {
                 ForceKillChrome();
-                throw new Exception("Failed to create connection", ex);
+                throw new ChromeProcessException("Failed to create connection", ex);
             }
 
         }
@@ -236,10 +237,14 @@ namespace PuppeteerSharp
 
             EventHandler exitedEvent = (sender, e) =>
             {
+                if (_options.LogProcess && !_processLoaded)
+                {
+                    Console.WriteLine($"PROCESS COUNT: {Interlocked.Increment(ref _processCount)}");
+                }
+
                 CleanUp();
 
-                var error = chromeProcess.StandardError.ReadToEnd();
-                taskWrapper.SetException(new ChromeProcessException($"Failed to launch chrome! {error}"));
+                taskWrapper.SetException(new ChromeProcessException($"Failed to launch chrome! {output}"));
             };
 
             chromeProcess.ErrorDataReceived += (sender, e) =>
@@ -340,7 +345,7 @@ namespace PuppeteerSharp
         {
             try
             {
-                if (_chromeProcess.Id != 0 && Process.GetProcessById(_chromeProcess.Id) != null)
+                if (_chromeProcess.Id != 0 && !_chromeProcess.HasExited && Process.GetProcessById(_chromeProcess.Id) != null)
                 {
                     _chromeProcess.Kill();
                     _chromeProcess.WaitForExit();


### PR DESCRIPTION
* Check if the process is running before killing it.
* Grab the output from the output variable instead of trying to read the stream again.

Closes #128 