### PR TITLE
Implemented Frame.waitForFunction tests

### DIFF
--- a/lib/PuppeteerSharp.Tests/Frame/WaitForFunctionTests.cs
+++ b/lib/PuppeteerSharp.Tests/Frame/WaitForFunctionTests.cs
@@ -7,13 +7,13 @@ namespace PuppeteerSharp.Tests.Frame
     [Collection("PuppeteerLoaderFixture collection")]
     public class WaitForFunctionTests : PuppeteerPageBaseTest
     {
-        [Fact(Skip = "not implemented yet")]
+        [Fact]
         public async Task ShouldPollOnInterval()
         {
             var success = false;
             var startTime = DateTime.Now;
             var polling = 100;
-            var watchdog = Page.WaitForFunctionAsync("() => window.__FOO === 'hit'"/*, { polling }*/)
+            var watchdog = Page.WaitForFunctionAsync("() => window.__FOO === 'hit'", new WaitForFunctionOptions { PollingInterval = polling })
                 .ContinueWith(_ => success = true);
             await Page.EvaluateExpressionAsync("window.__FOO = 'hit'");
             Assert.False(success);
@@ -42,6 +42,15 @@ namespace PuppeteerSharp.Tests.Frame
                 new WaitForFunctionOptions { Polling = WaitForFunctionPollingOption.Raf });
             await Page.EvaluateExpressionAsync("window.__FOO = 'hit'");
             await watchdog;
+        }
+
+        [Fact]
+        public async Task ShouldThrowNegativePollingInterval()
+        {
+            var exception = await Assert.ThrowsAsync<ArgumentOutOfRangeException>(()
+                => Page.WaitForFunctionAsync("() => !!document.body", new WaitForFunctionOptions { PollingInterval = -10 }));
+
+            Assert.Contains("Cannot poll with non-positive interval", exception.Message);
         }
 
         [Fact]

--- a/lib/PuppeteerSharp.Tests/Frame/WaitForFunctionTests.cs
+++ b/lib/PuppeteerSharp.Tests/Frame/WaitForFunctionTests.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace PuppeteerSharp.Tests.Frame
+{
+    [Collection("PuppeteerLoaderFixture collection")]
+    public class WaitForFunctionTests : PuppeteerPageBaseTest
+    {
+        [Fact(Skip = "not implemented yet")]
+        public async Task ShouldPollOnInterval()
+        {
+            var success = false;
+            var startTime = DateTime.Now;
+            var polling = 100;
+            var watchdog = Page.WaitForFunctionAsync("() => window.__FOO === 'hit'"/*, { polling }*/)
+                .ContinueWith(_ => success = true);
+            await Page.EvaluateExpressionAsync("window.__FOO = 'hit'");
+            Assert.False(success);
+            await Page.EvaluateExpressionAsync("document.body.appendChild(document.createElement('div'))");
+            await watchdog;
+            Assert.True((DateTime.Now - startTime).TotalMilliseconds > polling / 2);
+        }
+
+        [Fact]
+        public async Task ShouldPollOnMutation()
+        {
+            var success = false;
+            var watchdog = Page.WaitForFunctionAsync("() => window.__FOO === 'hit'",
+                new WaitForFunctionOptions { Polling = WaitForFunctionPollingOption.Mutation })
+                .ContinueWith(_ => success = true);
+            await Page.EvaluateExpressionAsync("window.__FOO = 'hit'");
+            Assert.False(success);
+            await Page.EvaluateExpressionAsync("document.body.appendChild(document.createElement('div'))");
+            await watchdog;
+        }
+
+        [Fact]
+        public async Task ShouldPollOnRaf()
+        {
+            var watchdog = Page.WaitForFunctionAsync("() => window.__FOO === 'hit'",
+                new WaitForFunctionOptions { Polling = WaitForFunctionPollingOption.Raf });
+            await Page.EvaluateExpressionAsync("window.__FOO = 'hit'");
+            await watchdog;
+        }
+
+        [Fact]
+        public async Task ShouldReturnTheSuccessValueAsAJSHandle()
+        {
+            Assert.Equal(5, await (await Page.WaitForFunctionAsync("() => 5")).JsonValue<int>());
+        }
+
+        [Fact]
+        public async Task ShouldReturnTheWindowAsASuccessValue()
+        {
+            Assert.NotNull(await Page.WaitForFunctionAsync("() => window"));
+        }
+
+        [Fact]
+        public async Task ShouldAcceptElementHandleArguments()
+        {
+            await Page.SetContentAsync("<div></div>");
+            var div = await Page.GetElementAsync("div");
+            var resolved = false;
+            var waitForFunction = Page.WaitForFunctionAsync("element => !element.parentElement", div)
+                .ContinueWith(_ => resolved = true);
+            Assert.False(resolved);
+            await Page.EvaluateFunctionAsync("element => element.remove()", div);
+            await waitForFunction;
+        }
+    }
+}

--- a/lib/PuppeteerSharp/Frame.cs
+++ b/lib/PuppeteerSharp/Frame.cs
@@ -192,7 +192,7 @@ namespace PuppeteerSharp
         internal Task WaitForTimeoutAsync(int milliseconds) => Task.Delay(milliseconds);
 
         internal Task<JSHandle> WaitForFunctionAsync(string script, WaitForFunctionOptions options, params object[] args)
-            => new WaitTask(this, script, options.Polling, options.Timeout, args).Task;
+            => new WaitTask(this, script, options.Polling, options.PollingInterval, options.Timeout, args).Task;
 
         internal async Task<ElementHandle> WaitForSelectorAsync(string selector, WaitForSelectorOptions options)
         {

--- a/lib/PuppeteerSharp/WaitForFunctionOptions.cs
+++ b/lib/PuppeteerSharp/WaitForFunctionOptions.cs
@@ -16,5 +16,10 @@
         /// An interval at which the <c>pageFunction</c> is executed. defaults to <see cref="WaitForFunctionPollingOption.Raf"/>
         /// </summary>
         public WaitForFunctionPollingOption Polling { get; set; } = WaitForFunctionPollingOption.Raf;
+
+        /// <summary>
+        /// An interval at which the <c>pageFunction</c> is executed. If no value is specified will use <see cref="Polling"/>
+        /// </summary>
+        public int? PollingInterval { get; set; }
     }
 }

--- a/lib/PuppeteerSharp/WaitTask.cs
+++ b/lib/PuppeteerSharp/WaitTask.cs
@@ -114,7 +114,7 @@ async function waitForPredicatePageFunction(predicateBody, polling, timeout, ...
             {
                 throw new ArgumentNullException(nameof(predicateBody));
             }
-            if(pollingInterval <= 10)
+            if (pollingInterval <= 0)
             {
                 throw new ArgumentOutOfRangeException(nameof(pollingInterval), "Cannot poll with non-positive interval");
             }


### PR DESCRIPTION
closes #139 

the following tests aren't relevant for C#:
- should accept a string (always a string...)
- should throw on bad polling value (we use an enum)