### PR TITLE
Don't await browse.close task

### DIFF
--- a/lib/PuppeteerSharp/Browser.cs
+++ b/lib/PuppeteerSharp/Browser.cs
@@ -108,7 +108,13 @@ namespace PuppeteerSharp
 
             IsClosed = true;
 
-            await _closeCallBack();
+            var closeTask = _closeCallBack();
+
+            if (closeTask != null)
+            {
+                await closeTask;
+            }
+
             Disconnect();
             Closed?.Invoke(this, new EventArgs());
         }

--- a/lib/PuppeteerSharp/Launcher.cs
+++ b/lib/PuppeteerSharp/Launcher.cs
@@ -195,7 +195,11 @@ namespace PuppeteerSharp
 
                 _connection = await Connection.Create(options.BrowserWSEndpoint, connectionDelay, keepAliveInterval);
 
-                return await Browser.CreateAsync(_connection, options, () => _connection.SendAsync("Browser.close", null));
+                return await Browser.CreateAsync(_connection, options, () =>
+                {
+                    var closeTask = _connection.SendAsync("Browser.close", null);
+                    return null;
+                });
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
We have a similar issue we had on #126. The GetAwaiter was hanging on some platforms (like a console app). For instance, the PuppeteerConnectTests.ShouldBeAbleToReconnectToADisconnectedBrowser (https://github.com/kblok/puppeteer-sharp/blob/9bebc1f8a305af365b99d18eedb135e68139104c/lib/PuppeteerSharp.Tests/Puppeteer/PuppeteerConnectTests.cs#L32) hangs if run on a console app.

The solution is quite similar to #126. As we don't need to wait for `Browse.close`.  We just trigger and forget it.

`_closeCallBack` might have a process kill (when we create a process) we would need to await, or a `Browser.close` (when we call connect) we can just trigger and forget.

closes #176