### PR TITLE
Fix demo build status badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Puppeteer Sharp
 
 [![NuGet](https://img.shields.io/nuget/v/PuppeteerSharp.svg?style=flat-square&label=nuget&colorB=green)][NugetUrl]
-[![Build status](https://ci.appveyor.com/api/projects/status/pwfkjb0c4jfdo7lc/branch/master?svg=true)][BuildUrl]
-[![Demo build status](https://ci.appveyor.com/api/projects/status/10g64a4aa0083wgf/branch/master?svg=true)][BuildDemoUrl]
+[![Build status](https://ci.appveyor.com/api/projects/status/pwfkjb0c4jfdo7lc/branch/master?svg=true&pendingText=master&failingText=master&passingText=master)][BuildUrl]
+[![Demo build status](https://ci.appveyor.com/api/projects/status/10g64a4aa0083wgf/branch/master?svg=true&pendingText=demo&failingText=demo&passingText=demo)][BuildDemoUrl]
 
 [NugetUrl]: https://www.nuget.org/packages/PuppeteerSharp/
 [BuildUrl]: https://ci.appveyor.com/project/kblok/puppeteer-sharp/branch/master

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![NuGet](https://img.shields.io/nuget/v/PuppeteerSharp.svg?style=flat-square&label=nuget&colorB=green)][NugetUrl]
 [![Build status](https://ci.appveyor.com/api/projects/status/pwfkjb0c4jfdo7lc/branch/master?svg=true)][BuildUrl]
-[![Build status](https://ci.appveyor.com/api/projects/status/10g64a4aa0083wgf/branch/master?svg=true)][BuildUrl]
+[![Demo build status](https://ci.appveyor.com/api/projects/status/10g64a4aa0083wgf/branch/master?svg=true)][BuildDemoUrl]
 
 [NugetUrl]: https://www.nuget.org/packages/PuppeteerSharp/
 [BuildUrl]: https://ci.appveyor.com/project/kblok/puppeteer-sharp/branch/master


### PR DESCRIPTION
I'm not sure these changes are correct, but as-is the two AppVeyor 'build status' badges in the README are pointing to the same (AppVeyor) project. Based on the markup in the README file itself, I'm guessing one of the badges was meant to reference the build status of the demo project.

But, even with these changes, there's no visual distinction between the two build status badges. If you have an idea how that should be affected, I'll take a stab at it.