### PR TITLE
Fix PDF README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ var browser = await Puppeteer.LaunchAsync(new LaunchOptions
 }, chromiumRevision);
 var page = await browser.NewPageAsync();
 await page.GoToAsync("http://www.google.com");
-await page.PdfAsync(outputFile));
+await page.PdfAsync(outputFile);
 ```
 
 ## Inject HTML


### PR DESCRIPTION
This remove an extraneous `)` in the PDF example in the README.