### PR TITLE
Fix Chromium downloader on 32bits apps runnning on a x64 platform

### DIFF
--- a/demos/PuppeteerSharpPdfDemo/PuppeteerSharpPdfDemo.csproj
+++ b/demos/PuppeteerSharpPdfDemo/PuppeteerSharpPdfDemo.csproj
@@ -12,7 +12,7 @@
     <LangVersion>7.2</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="PuppeteerSharp" Version="0.8.0" />
+    <PackageReference Include="PuppeteerSharp" Version="1.0.1" />
   </ItemGroup>
 
 </Project>

--- a/lib/PuppeteerSharp/Downloader.cs
+++ b/lib/PuppeteerSharp/Downloader.cs
@@ -65,7 +65,7 @@ namespace PuppeteerSharp
                 }
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 {
-                    return IntPtr.Size == 8 ? Platform.Win64 : Platform.Win32;
+                    return RuntimeInformation.OSArchitecture == Architecture.X64 ? Platform.Win64 : Platform.Win32;
                 }
 
                 return Platform.Unknown;

--- a/lib/PuppeteerSharp/PuppeteerSharp.csproj
+++ b/lib/PuppeteerSharp/PuppeteerSharp.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackOnBuild>true</PackOnBuild>
-    <PackageVersion>1.0.0</PackageVersion>
+    <PackageVersion>1.0.1</PackageVersion>
     <Authors>Darío Kondratiuk</Authors>
     <Owners>Darío Kondratiuk</Owners>
     <PackageProjectUrl>https://github.com/kblok/puppeteer-sharp</PackageProjectUrl>
@@ -12,6 +12,11 @@
     <Description>Headless Chrome .NET API</Description>
     <PackageId>PuppeteerSharp</PackageId>
     <PackageReleaseNotes>
+1.0.1
+==============
+* Fix Chromium downloader on 32bits apps runnning on a x64 platform
+1.0.0
+==============
 * New Features
  * Request.RespondAsync support.
  * CSS and JS Coverage.
@@ -55,7 +60,7 @@
  * PuppeteerSharp.DeviceDescriptors => PuppeteerSharp.Mobile.DeviceDescriptors
  * PuppeteerSharp.DeviceDescriptorName => PuppeteerSharp.Mobile.DeviceDescriptorName
     </PackageReleaseNotes>
-    <ReleaseVersion>1.0.0</ReleaseVersion>
+    <ReleaseVersion>1.0.1</ReleaseVersion>
     <SynchReleaseVersion>false</SynchReleaseVersion>
   </PropertyGroup>
   <PropertyGroup>


### PR DESCRIPTION
`IntPtr.Size == 8` checks if the application is in 64bits. We need to check whether the host OS is 64bits or not.

closes #294 