### PR TITLE
Update GotoTests and PuppeteerLaunchTests

### DIFF
--- a/lib/PuppeteerSharp.TestServer/wwwroot/self-request.html
+++ b/lib/PuppeteerSharp.TestServer/wwwroot/self-request.html
@@ -1,0 +1,5 @@
+<script>
+var req = new XMLHttpRequest();
+req.open('GET', '/self-request.html');
+req.send(null);
+</script>

--- a/lib/PuppeteerSharp.Tests/PageTests/GotoTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/GotoTests.cs
@@ -25,7 +25,7 @@ namespace PuppeteerSharp.Tests.PageTests
         [Fact]
         public async Task ShouldNavigateToEmptyPageWithDOMContentLoaded()
         {
-            var response = await Page.GoToAsync(TestConstants.EmptyPage, waitUntil: new WaitUntilNavigation[] {
+            var response = await Page.GoToAsync(TestConstants.EmptyPage, waitUntil: new[] {
                 WaitUntilNavigation.DOMContentLoaded
             });
             Assert.Equal(HttpStatusCode.OK, response.Status);

--- a/lib/PuppeteerSharp.Tests/PageTests/GotoTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/GotoTests.cs
@@ -22,8 +22,17 @@ namespace PuppeteerSharp.Tests.PageTests
             Assert.Null(response);
         }
 
+        [Fact]
+        public async Task ShouldNavigateToEmptyPageWithDOMContentLoaded()
+        {
+            var response = await Page.GoToAsync(TestConstants.EmptyPage, waitUntil: new WaitUntilNavigation[] {
+                WaitUntilNavigation.DOMContentLoaded
+            });
+            Assert.Equal(HttpStatusCode.OK, response.Status);
+            Assert.Null(response.SecurityDetails);
+        }
+
         [Theory]
-        [InlineData(WaitUntilNavigation.DOMContentLoaded)]
         [InlineData(WaitUntilNavigation.Networkidle0)]
         [InlineData(WaitUntilNavigation.Networkidle2)]
         public async Task ShouldNavigateToEmptyPage(WaitUntilNavigation waitUntil)
@@ -242,6 +251,14 @@ namespace PuppeteerSharp.Tests.PageTests
             Assert.Equal(TestConstants.EmptyPage, response.Url);
             Assert.Single(requests);
             Assert.Equal(TestConstants.EmptyPage, requests[0].Url);
+        }
+
+        [Fact]
+        public async Task ShouldWorkWithSelfRequestingPage()
+        {
+            var response = await Page.GoToAsync(TestConstants.EmptyPage + "/self-request.html");
+            Assert.Equal(HttpStatusCode.OK, response.Status);
+            Assert.Contains("self-request.html", response.Url);
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/PageTests/GotoTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/GotoTests.cs
@@ -257,7 +257,7 @@ namespace PuppeteerSharp.Tests.PageTests
         [Fact]
         public async Task ShouldWorkWithSelfRequestingPage()
         {
-            var response = await Page.GoToAsync(TestConstants.EmptyPage + "/self-request.html");
+            var response = await Page.GoToAsync(TestConstants.ServerUrl + "/self-request.html");
             Assert.Equal(HttpStatusCode.OK, response.Status);
             Assert.Contains("self-request.html", response.Url);
         }

--- a/lib/PuppeteerSharp.Tests/PageTests/GotoTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/GotoTests.cs
@@ -25,7 +25,8 @@ namespace PuppeteerSharp.Tests.PageTests
         [Fact]
         public async Task ShouldNavigateToEmptyPageWithDOMContentLoaded()
         {
-            var response = await Page.GoToAsync(TestConstants.EmptyPage, waitUntil: new[] {
+            var response = await Page.GoToAsync(TestConstants.EmptyPage, waitUntil: new[]
+            {
                 WaitUntilNavigation.DOMContentLoaded
             });
             Assert.Equal(HttpStatusCode.OK, response.Status);

--- a/lib/PuppeteerSharp/SecurityDetails.cs
+++ b/lib/PuppeteerSharp/SecurityDetails.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace PuppeteerSharp
@@ -39,26 +40,31 @@ namespace PuppeteerSharp
         /// Gets the name of the subject.
         /// </summary>
         /// <value>The name of the subject.</value>
-        public string SubjectName { get; }
+        [JsonProperty("subjectName")]
+        public string SubjectName { get; internal set; }
         /// <summary>
         /// Gets the issuer.
         /// </summary>
         /// <value>The issuer.</value>
-        public string Issuer { get; }
+        [JsonProperty("issuer")]
+        public string Issuer { get; internal set; }
         /// <summary>
         /// Gets the valid from.
         /// </summary>
         /// <value>The valid from.</value>
-        public int ValidFrom { get; }
+        [JsonProperty("validFrom")]
+        public int ValidFrom { get; internal set; }
         /// <summary>
         /// Gets the valid to.
         /// </summary>
         /// <value>The valid to.</value>
-        public int ValidTo { get; }
+        [JsonProperty("validTo")]
+        public int ValidTo { get; internal set; }
         /// <summary>
         /// Gets the protocol.
         /// </summary>
         /// <value>The protocol.</value>
-        public string Protocol { get; }
+        [JsonProperty("protocol")]
+        public string Protocol { get; internal set; }
     }
 }


### PR DESCRIPTION
Basically, we're supporting SecurityDetails deserializations.

closes #270 
closes #276 