### PR TITLE
fixed NuGet badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Puppeteer Sharp
 
-[![NuGet](https://img.shields.io/nuget/v/PuppeteerSharp.svg?style=flat-square&label=nuget&colorB=green)][NugetUrl]
+[![NuGet](https://buildstats.info/nuget/PuppeteerSharp)][NugetUrl]
 [![Build status](https://ci.appveyor.com/api/projects/status/pwfkjb0c4jfdo7lc/branch/master?svg=true&pendingText=master&failingText=master&passingText=master)][BuildUrl]
 [![Demo build status](https://ci.appveyor.com/api/projects/status/10g64a4aa0083wgf/branch/master?svg=true&pendingText=demo&failingText=demo&passingText=demo)][BuildDemoUrl]
 [![CodeFactor](https://www.codefactor.io/repository/github/ninetaillabs/varaniumsharp.initiator/badge)][CodeFactorUrl]


### PR DESCRIPTION
the readme will now show the nuget stats

before:
![image](https://user-images.githubusercontent.com/9786571/41966450-cf9bbbcc-7a07-11e8-8df3-938ba8920178.png)

after:
![image](https://user-images.githubusercontent.com/9786571/41966423-be079fe8-7a07-11e8-9ac3-270e77536072.png)
