### PR TITLE
fix an duplicated key issue, so the code behaviour same as github.com…

### DIFF
--- a/lib/PuppeteerSharp/Page.cs
+++ b/lib/PuppeteerSharp/Page.cs
@@ -1284,7 +1284,13 @@ namespace PuppeteerSharp
             var responses = new Dictionary<string, Response>();
 
             EventHandler<ResponseCreatedEventArgs> createResponseEventListener = (object sender, ResponseCreatedEventArgs e) =>
-                responses.Add(e.Response.Url, e.Response);
+            {
+                if(!responses.ContainsKey(e.Response.Url)){
+                    responses.Add(e.Response.Url, e.Response);
+                }else{
+                    responses[e.Response.Url] = e.Response;
+                }
+            }
 
             _networkManager.Response += createResponseEventListener;
 


### PR DESCRIPTION
I got a weird issue recently, the code randomly throw an exception which says

> The active test run was aborted. Reason: Unhandled Exception: System.ArgumentException: An item with the same key has already been added. Key: https://cdn.jsdelivr.net/npm/font-awesome@4.7.0/fonts/fontawesome-webfont.woff2?v=4.7.0

However I did not able to identify why this is happening in my project, and Fiddler also says there is only one request logged to that url, so I cannot create a demo page for you.

I have similar code running based on [GoogleChrome/puppeteer](https://github.com/GoogleChrome/puppeteer) but never got this issue, so I digged a little in its code and found a minor difference [at here](https://github.com/GoogleChrome/puppeteer/blob/6ca43cf76187a33c62d8822fe363196bc3ebd216/lib/Page.js#L627).

As you can see, the `responses` is a `Map` object, and it uses `responses.set(response.url(), response)` to update it. And in puppeteer-sharp, the corresponding responses object is using a Dictionary to contains this key-value pair.

The difference is, `Map.set` is capable of 2 things: create the key-value pair when key not exist, and update the value if key exists. But `Dictionary.Add` in .net will throw exception if key already in dictionary.

So I modified the code to make it update the value if the key already exists.

Thanks.