### PR TITLE
Disable WebSocket ping

### DIFF
--- a/lib/PuppeteerSharp/ConnectOptions.cs
+++ b/lib/PuppeteerSharp/ConnectOptions.cs
@@ -1,4 +1,6 @@
-﻿namespace PuppeteerSharp
+﻿using System;
+
+namespace PuppeteerSharp
 {
     /// <summary>
     /// Options for connecting to an existing browser.
@@ -28,6 +30,7 @@
         /// <summary>
         /// Keep alive value.
         /// </summary>
-        public int KeepAliveInterval { get; set; } = 30;
+        [Obsolete("Chromium doesn't support pings yet (see: https://bugs.chromium.org/p/chromium/issues/detail?id=865002)")]
+        public int KeepAliveInterval { get; set; } = 0;
     }
 }

--- a/lib/PuppeteerSharp/Launcher.cs
+++ b/lib/PuppeteerSharp/Launcher.cs
@@ -149,7 +149,7 @@ namespace PuppeteerSharp
                 _chromiumLaunched = true;
 
                 var connectionDelay = options.SlowMo;
-                var keepAliveInterval = options.KeepAliveInterval;
+                var keepAliveInterval = 0;
 
                 _connection = await Connection.Create(options.BrowserWSEndpoint, connectionDelay, keepAliveInterval, _loggerFactory);
 


### PR DESCRIPTION
Chromium doesn't support WebSockets pings yet, so we need to remove the Keep Alive usage.

This issue was reported here https://bugs.chromium.org/p/chromium/issues/detail?id=865002

closes #381