### PR TITLE
ElementHandle EvaluateFunctionAsync examples

### DIFF
--- a/lib/PuppeteerSharp.Tests/ElementHandleTests/EvaluateFunctionTests.cs
+++ b/lib/PuppeteerSharp.Tests/ElementHandleTests/EvaluateFunctionTests.cs
@@ -1,0 +1,35 @@
+﻿using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace PuppeteerSharp.Tests.ElementHandleTests
+{
+    [Collection("PuppeteerLoaderFixture collection")]
+    public class EvaluateFunctionTests : PuppeteerPageBaseTest
+    {
+        public EvaluateFunctionTests(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task ShouldWork()
+        {
+            await Page.SetContentAsync("<html><body><div class='tweet'><div class='like'>100</div><div class='retweets'>10</div></div></body></html>");
+            var tweet = await Page.QuerySelectorAsync(".tweet");
+            var content = await tweet.QuerySelectorAsync(".like")
+                .EvaluateFunctionAsync<string>("node => node.innerText");
+            Assert.Equal("100", content);
+        }
+
+        [Fact]
+        public async Task ShouldRetrieveContentFromSubtree()
+        {
+            var htmlContent = "<div class='a'>not-a-child-div</div><div id='myId'><div class='a'>a-child-div</div></div>";
+            await Page.SetContentAsync(htmlContent);
+            var elementHandle = await Page.QuerySelectorAsync("#myId");
+            var content = await elementHandle.QuerySelectorAsync(".a")
+                .EvaluateFunctionAsync<string>("node => node.innerText");
+            Assert.Equal("a-child-div", content);
+        }
+    }
+}


### PR DESCRIPTION
As we [decided on v0.7](http://www.hardkoded.com/blogs/puppeteer-sharp-v07-released). The `$eval` function will be ported using 2 method calls `QuerySelectorAsync` and `EvaluateFunctionAsync`.

I'm adding the test as an example of this feature mapping.

closes #449