### PR TITLE
Allow user gesture restricted code to be run in Page.EvaluateExpressionAsync

### DIFF
--- a/lib/PuppeteerSharp.Tests/PageTests/EvaluateTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/EvaluateTests.cs
@@ -200,8 +200,8 @@ namespace PuppeteerSharp.Tests.PageTests
         }
 
         [Fact]
-        public async Task ShouldSimulateAUserGesture()
-            => await Page.EvaluateExpressionAsync(@"(
+        public Task ShouldSimulateAUserGesture()
+            => Page.EvaluateExpressionAsync(@"(
             function playAudio()
             {
                 const audio = document.createElement('audio');

--- a/lib/PuppeteerSharp.Tests/PageTests/EvaluateTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/EvaluateTests.cs
@@ -198,5 +198,16 @@ namespace PuppeteerSharp.Tests.PageTests
 
             Assert.Null(result);
         }
+
+        [Fact]
+        public async Task ShouldSimulateAUserGesture()
+            => await Page.EvaluateExpressionAsync(@"(
+            function playAudio()
+            {
+                const audio = document.createElement('audio');
+                audio.src = 'data:audio/wav;base64,UklGRiQAAABXQVZFZm10IBAAAAABAAEARKwAAIhYAQACABAAZGF0YQAAAAA=';
+                // This returns a promise which throws if it was not triggered by a user gesture.
+                return audio.play();
+            })()");
     }
 }

--- a/lib/PuppeteerSharp/ExecutionContext.cs
+++ b/lib/PuppeteerSharp/ExecutionContext.cs
@@ -142,10 +142,11 @@ namespace PuppeteerSharp
 
             return await EvaluateHandleAsync("Runtime.evaluate", new Dictionary<string, object>
             {
-                {"contextId", _contextId},
-                {"expression", script},
-                {"returnByValue", false},
-                {"awaitPromise", true}
+                ["expression"] = script,
+                ["contextId"] = _contextId,
+                ["returnByValue"] = false,
+                ["awaitPromise"] = true,
+                ["userGesture"] = true
             });
         }
 
@@ -158,11 +159,12 @@ namespace PuppeteerSharp
 
             return await EvaluateHandleAsync("Runtime.callFunctionOn", new Dictionary<string, object>
             {
-                {"functionDeclaration", script },
-                {"executionContextId", _contextId},
-                {"arguments", args.Select(FormatArgument)},
-                {"returnByValue", false},
-                {"awaitPromise", true}
+                ["functionDeclaration"] = script,
+                ["executionContextId"] = _contextId,
+                ["arguments"] = args.Select(FormatArgument),
+                ["returnByValue"] = false,
+                ["awaitPromise"] = true,
+                ["userGesture"] = true
             });
         }
 

--- a/lib/PuppeteerSharp/ScreenshotType.cs
+++ b/lib/PuppeteerSharp/ScreenshotType.cs
@@ -1,8 +1,18 @@
 ﻿namespace PuppeteerSharp
 {
+    /// <summary>
+    /// Screenshot file type.
+    /// </summary>
+    /// <seealso cref="ScreenshotOptions"/>
     public enum ScreenshotType
     {
+        /// <summary>
+        /// JPEG type.
+        /// </summary>
         Jpeg,
+        /// <summary>
+        /// PNG type.
+        /// </summary>
         Png
     }
 }


### PR DESCRIPTION
closes #448 

Notice that this test has only one call because we always execution functions using strings