### PR TITLE
Add option to run 'beforeunload' when closing the page

### DIFF
--- a/lib/PuppeteerSharp.TestServer/wwwroot/beforeunload.html
+++ b/lib/PuppeteerSharp.TestServer/wwwroot/beforeunload.html
@@ -1,0 +1,5 @@
+<script>
+window.addEventListener('beforeunload', event => {
+  event.returnValue = 'Leave?';
+});
+</script>

--- a/lib/PuppeteerSharp/Page.cs
+++ b/lib/PuppeteerSharp/Page.cs
@@ -995,16 +995,28 @@ namespace PuppeteerSharp
         /// Closes the page.
         /// </summary>
         /// <returns>Task.</returns>
-        public Task CloseAsync()
+        public Task CloseAsync(PageCloseOptions options = null)
         {
             if (!(Client?.Connection?.IsClosed ?? true))
             {
-                return Client.Connection.SendAsync("Target.closeTarget", new
-                {
-                    targetId = Target.TargetId
-                }).ContinueWith((task) => Target.CloseTask);
-            }
+                var runBeforeUnload = options?.RunBeforeUnload ?? false;
 
+                if (runBeforeUnload)
+                {
+                    return Client.SendAsync("Page.close");
+                }
+                else
+                {
+                    return Client.Connection.SendAsync("Target.closeTarget", new
+                    {
+                        targetId = Target.TargetId
+                    }).ContinueWith((task) => Target.CloseTask);
+                }
+            }
+            else
+            {
+                _logger.LogWarning("Protocol error: Connection closed. Most likely the page has been closed.");
+            }
             return Task.CompletedTask;
         }
 

--- a/lib/PuppeteerSharp/PageCloseOptions.cs
+++ b/lib/PuppeteerSharp/PageCloseOptions.cs
@@ -1,0 +1,15 @@
+﻿namespace PuppeteerSharp
+{
+    /// <summary>
+    /// Page close options.
+    /// </summary>
+    /// <seealso cref="Page.CloseAsync(PageCloseOptions)"/>
+    public class PageCloseOptions
+    {
+        /// <summary>
+        /// Defaults to <c>false</c>. Whether to run the beforeunload page handlers.
+        /// </summary>
+        /// <see href="https://developer.mozilla.org/en-US/docs/Web/Events/beforeunload"/>
+        public bool RunBeforeUnload { get; set; }
+    }
+}


### PR DESCRIPTION
closes #447 

Notice that I didn't use the WaitEvent method because our WaitEvent method listens to chromium messages while puppeteer's listens to NodeJS events.