### PR TITLE
Added .ConfigureAwait(false) to each await

### DIFF
--- a/lib/PuppeteerSharp/Browser.cs
+++ b/lib/PuppeteerSharp/Browser.cs
@@ -141,11 +141,11 @@ namespace PuppeteerSharp
             string targetId = (await Connection.SendAsync("Target.createTarget", new Dictionary<string, object>
             {
                 ["url"] = "about:blank"
-            })).targetId.ToString();
+            }).ConfigureAwait(false)).targetId.ToString();
 
             var target = TargetsMap[targetId];
-            await target.InitializedTask;
-            return await target.PageAsync();
+            await target.InitializedTask.ConfigureAwait(false);
+            return await target.PageAsync().ConfigureAwait(false);
         }
 
         /// <summary>
@@ -159,7 +159,7 @@ namespace PuppeteerSharp
         /// </summary>
         /// <returns>Task which resolves to an array of all open pages.</returns>
         public async Task<Page[]> PagesAsync()
-            => (await Task.WhenAll(Targets().Select(target => target.PageAsync()))).Where(x => x != null).ToArray();
+            => (await Task.WhenAll(Targets().Select(target => target.PageAsync())).ConfigureAwait(false)).Where(x => x != null).ToArray();
 
         /// <summary>
         /// Gets the browser's version
@@ -170,7 +170,7 @@ namespace PuppeteerSharp
         /// </remarks>
         public async Task<string> GetVersionAsync()
         {
-            dynamic version = await Connection.SendAsync("Browser.getVersion");
+            dynamic version = await Connection.SendAsync("Browser.getVersion").ConfigureAwait(false);
             return version.product.ToString();
         }
 
@@ -183,7 +183,7 @@ namespace PuppeteerSharp
         /// </remarks>
         public async Task<string> GetUserAgentAsync()
         {
-            dynamic version = await Connection.SendAsync("Browser.getVersion");
+            dynamic version = await Connection.SendAsync("Browser.getVersion").ConfigureAwait(false);
             return version.userAgent.ToString();
         }
 
@@ -210,7 +210,7 @@ namespace PuppeteerSharp
 
             if (closeTask != null)
             {
-                await closeTask;
+                await closeTask.ConfigureAwait(false);
             }
 
             Disconnect();
@@ -231,11 +231,11 @@ namespace PuppeteerSharp
             switch (e.MessageID)
             {
                 case "Target.targetCreated":
-                    await CreateTargetAsync(e.MessageData.ToObject<TargetCreatedResponse>());
+                    await CreateTargetAsync(e.MessageData.ToObject<TargetCreatedResponse>()).ConfigureAwait(false);
                     return;
 
                 case "Target.targetDestroyed":
-                    await DestroyTargetAsync(e.MessageData.ToObject<TargetDestroyedResponse>());
+                    await DestroyTargetAsync(e.MessageData.ToObject<TargetDestroyedResponse>()).ConfigureAwait(false);
                     return;
 
                 case "Target.targetInfoChanged":
@@ -267,7 +267,7 @@ namespace PuppeteerSharp
 
             target.CloseTaskWrapper.TrySetResult(true);
 
-            if (await target.InitializedTask)
+            if (await target.InitializedTask.ConfigureAwait(false))
             {
                 TargetDestroyed?.Invoke(this, new TargetChangedArgs
                 {
@@ -290,7 +290,7 @@ namespace PuppeteerSharp
 
             TargetsMap[e.TargetInfo.TargetId] = target;
 
-            if (await target.InitializedTask)
+            if (await target.InitializedTask.ConfigureAwait(false))
             {
                 TargetCreated?.Invoke(this, new TargetChangedArgs
                 {
@@ -309,7 +309,7 @@ namespace PuppeteerSharp
             await connection.SendAsync("Target.setDiscoverTargets", new
             {
                 discover = true
-            });
+            }).ConfigureAwait(false);
 
             return browser;
         }

--- a/lib/PuppeteerSharp/BrowserFetcher.cs
+++ b/lib/PuppeteerSharp/BrowserFetcher.cs
@@ -97,7 +97,7 @@ namespace PuppeteerSharp
             {
                 RequestUri = new Uri(url),
                 Method = HttpMethod.Head
-            });
+            }).ConfigureAwait(false);
 
             return response.IsSuccessStatusCode;
         }
@@ -179,7 +179,7 @@ namespace PuppeteerSharp
             {
                 webClient.DownloadProgressChanged += DownloadProgressChanged;
             }
-            await webClient.DownloadFileTaskAsync(new Uri(url), zipPath);
+            await webClient.DownloadFileTaskAsync(new Uri(url), zipPath).ConfigureAwait(false);
 
             if (Platform == Platform.MacOS)
             {

--- a/lib/PuppeteerSharp/CDPSession.cs
+++ b/lib/PuppeteerSharp/CDPSession.cs
@@ -86,7 +86,7 @@ namespace PuppeteerSharp
 
         internal async Task<T> SendAsync<T>(string method, dynamic args = null)
         {
-            var content = await SendAsync(method, true, args);
+            var content = await SendAsync(method, true, args).ConfigureAwait(false);
             return JsonConvert.DeserializeObject<T>(content);
         }
 
@@ -125,7 +125,7 @@ namespace PuppeteerSharp
                 {
                     {"sessionId", SessionId},
                     {"message", message}
-                });
+                }).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -136,7 +136,7 @@ namespace PuppeteerSharp
                 }
             }
 
-            return await callback.TaskWrapper.Task;
+            return await callback.TaskWrapper.Task.ConfigureAwait(false);
         }
 
         /// <summary>

--- a/lib/PuppeteerSharp/Connection.cs
+++ b/lib/PuppeteerSharp/Connection.cs
@@ -101,19 +101,19 @@ namespace PuppeteerSharp
 
             var encoded = Encoding.UTF8.GetBytes(message);
             var buffer = new ArraySegment<byte>(encoded, 0, encoded.Length);
-            await _socketQueue.Enqueue(() => WebSocket.SendAsync(buffer, WebSocketMessageType.Text, true, default));
+            await _socketQueue.Enqueue(() => WebSocket.SendAsync(buffer, WebSocketMessageType.Text, true, default)).ConfigureAwait(false);
 
             if (method == CloseMessage)
             {
                 StopReading();
             }
 
-            return await _responses[id].TaskWrapper.Task;
+            return await _responses[id].TaskWrapper.Task.ConfigureAwait(false);
         }
 
         internal async Task<CDPSession> CreateSessionAsync(string targetId)
         {
-            string sessionId = (await SendAsync("Target.attachToTarget", new { targetId })).sessionId;
+            string sessionId = (await SendAsync("Target.attachToTarget", new { targetId }).ConfigureAwait(false)).sessionId;
             var session = new CDPSession(this, targetId, sessionId);
             _sessions.Add(sessionId, session);
             return session;
@@ -176,7 +176,7 @@ namespace PuppeteerSharp
                     {
                         result = await WebSocket.ReceiveAsync(
                             new ArraySegment<byte>(buffer),
-                            _websocketReaderCancellationSource.Token);
+                            _websocketReaderCancellationSource.Token).ConfigureAwait(false);
                     }
                     catch (Exception) when (_stopReading)
                     {
@@ -212,7 +212,7 @@ namespace PuppeteerSharp
                 {
                     if (Delay > 0)
                     {
-                        await Task.Delay(Delay);
+                        await Task.Delay(Delay).ConfigureAwait(false);
                     }
 
                     ProcessResponse(response);

--- a/lib/PuppeteerSharp/Dialog.cs
+++ b/lib/PuppeteerSharp/Dialog.cs
@@ -56,9 +56,9 @@ namespace PuppeteerSharp
         /// </summary>
         /// <returns>Task which resolves when the dialog has been accepted.</returns>
         /// <param name="promptText">A text to enter in prompt. Does not cause any effects if the dialog's type is not prompt.</param>
-        public async Task Accept(string promptText = "")
+        public Task Accept(string promptText = "")
         {
-            await _client.SendAsync("Page.handleJavaScriptDialog", new Dictionary<string, object>
+            return _client.SendAsync("Page.handleJavaScriptDialog", new Dictionary<string, object>
             {
                 {"accept", true},
                 {"promptText", promptText}
@@ -69,9 +69,9 @@ namespace PuppeteerSharp
         /// Dismiss the dialog.
         /// </summary>
         /// <returns>Task which resolves when the dialog has been dismissed.</returns>
-        public async Task Dismiss()
+        public Task Dismiss()
         {
-            await _client.SendAsync("Page.handleJavaScriptDialog", new Dictionary<string, object>
+            return _client.SendAsync("Page.handleJavaScriptDialog", new Dictionary<string, object>
             {
                 {"accept", false}
             });

--- a/lib/PuppeteerSharp/EmulationManager.cs
+++ b/lib/PuppeteerSharp/EmulationManager.cs
@@ -47,7 +47,7 @@ namespace PuppeteerSharp
                     enabled = viewport.HasTouch,
                     configuration = viewport.IsMobile ? "mobile" : "desktop"
                 })
-            });
+            }).ConfigureAwait(false);
 
             var reloadNeeded = false;
             if (viewport.HasTouch && string.IsNullOrEmpty(_injectedTouchScriptId))
@@ -55,7 +55,7 @@ namespace PuppeteerSharp
                 //TODO: It's not clear what to do here
                 /*
                 var source = $"({ injectedTouchEventsFunction})()";
-                this._injectedTouchScriptId = (await this._client.send('Page.addScriptToEvaluateOnNewDocument', { source })).identifier;
+                this._injectedTouchScriptId = (await this._client.send('Page.addScriptToEvaluateOnNewDocument', { source }).ConfigureAwait(false)).identifier;
                 reloadNeeded = true;
                 */
             }
@@ -64,7 +64,7 @@ namespace PuppeteerSharp
                 await _client.SendAsync("Page.removeScriptToEvaluateOnNewDocument", new
                 {
                     identifier = _injectedTouchScriptId
-                });
+                }).ConfigureAwait(false);
                 _injectedTouchScriptId = null;
                 reloadNeeded = true;
             }

--- a/lib/PuppeteerSharp/ExecutionContext.cs
+++ b/lib/PuppeteerSharp/ExecutionContext.cs
@@ -128,7 +128,7 @@ namespace PuppeteerSharp
             dynamic response = await _client.SendAsync("Runtime.queryObjects", new Dictionary<string, object>
             {
                 {"prototypeObjectId", objectId.ToString()}
-            });
+            }).ConfigureAwait(false);
 
             return ObjectHandleFactory(response.objects);
         }
@@ -147,7 +147,7 @@ namespace PuppeteerSharp
                 ["returnByValue"] = false,
                 ["awaitPromise"] = true,
                 ["userGesture"] = true
-            });
+            }).ConfigureAwait(false);
         }
 
         internal async Task<JSHandle> EvaluateFunctionHandleAsync(string script, params object[] args)
@@ -165,18 +165,18 @@ namespace PuppeteerSharp
                 ["returnByValue"] = false,
                 ["awaitPromise"] = true,
                 ["userGesture"] = true
-            });
+            }).ConfigureAwait(false);
         }
 
         private async Task<T> EvaluateAsync<T>(Task<JSHandle> handleEvaluator)
         {
-            var handle = await handleEvaluator;
+            var handle = await handleEvaluator.ConfigureAwait(false);
             var result = default(T);
 
             try
             {
                 result = await handle.JsonValueAsync<T>()
-                    .ContinueWith(jsonTask => jsonTask.Exception != null ? default : jsonTask.Result);
+                    .ContinueWith(jsonTask => jsonTask.Exception != null ? default : jsonTask.Result).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -187,13 +187,13 @@ namespace PuppeteerSharp
                 }
                 throw new EvaluationFailedException(ex.Message, ex);
             }
-            await handle.DisposeAsync();
+            await handle.DisposeAsync().ConfigureAwait(false);
             return result;
         }
 
         private async Task<JSHandle> EvaluateHandleAsync(string method, dynamic args)
         {
-            dynamic response = await _client.SendAsync(method, args);
+            dynamic response = await _client.SendAsync(method, args).ConfigureAwait(false);
 
             if (response.exceptionDetails != null)
             {

--- a/lib/PuppeteerSharp/Extensions.cs
+++ b/lib/PuppeteerSharp/Extensions.cs
@@ -18,7 +18,7 @@ namespace PuppeteerSharp
         /// <exception cref="SelectorException">If <paramref name="elementHandleTask"/> resolves to <c>null</c></exception>
         public static async Task<T> EvaluateFunctionAsync<T>(this Task<ElementHandle> elementHandleTask, string pageFunction, params object[] args)
         {
-            var elementHandle = await elementHandleTask;
+            var elementHandle = await elementHandleTask.ConfigureAwait(false);
             if (elementHandle == null)
             {
                 throw new SelectorException($"Error: failed to find element matching selector");
@@ -27,8 +27,8 @@ namespace PuppeteerSharp
             var newArgs = new object[args.Length + 1];
             newArgs[0] = elementHandle;
             args.CopyTo(newArgs, 1);
-            var result = await elementHandle.ExecutionContext.EvaluateFunctionAsync<T>(pageFunction, newArgs);
-            await elementHandle.DisposeAsync();
+            var result = await elementHandle.ExecutionContext.EvaluateFunctionAsync<T>(pageFunction, newArgs).ConfigureAwait(false);
+            await elementHandle.DisposeAsync().ConfigureAwait(false);
             return result;
         }
 
@@ -42,13 +42,13 @@ namespace PuppeteerSharp
         /// <returns>Task which resolves to the return value of <c>pageFunction</c></returns>
         public static async Task<T> EvaluateFunctionAsync<T>(this Task<JSHandle> arrayHandleTask, string pageFunction, params object[] args)
         {
-            var arrayHandle = await arrayHandleTask;
+            var arrayHandle = await arrayHandleTask.ConfigureAwait(false);
 
             var newArgs = new object[args.Length + 1];
             newArgs[0] = arrayHandle;
             args.CopyTo(newArgs, 1);
-            var result = await arrayHandle.ExecutionContext.EvaluateFunctionAsync<T>(pageFunction, newArgs);
-            await arrayHandle.DisposeAsync();
+            var result = await arrayHandle.ExecutionContext.EvaluateFunctionAsync<T>(pageFunction, newArgs).ConfigureAwait(false);
+            await arrayHandle.DisposeAsync().ConfigureAwait(false);
             return result;
         }
     }

--- a/lib/PuppeteerSharp/Frame.cs
+++ b/lib/PuppeteerSharp/Frame.cs
@@ -109,8 +109,8 @@ namespace PuppeteerSharp
         /// <seealso cref="Page.EvaluateExpressionAsync(string)"/>
         public async Task<dynamic> EvaluateExpressionAsync(string script)
         {
-            var context = await GetExecutionContextAsync();
-            return await context.EvaluateExpressionAsync(script);
+            var context = await GetExecutionContextAsync().ConfigureAwait(false);
+            return await context.EvaluateExpressionAsync(script).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -126,8 +126,8 @@ namespace PuppeteerSharp
         /// <seealso cref="Page.EvaluateExpressionAsync{T}(string)"/>
         public async Task<T> EvaluateExpressionAsync<T>(string script)
         {
-            var context = await GetExecutionContextAsync();
-            return await context.EvaluateExpressionAsync<T>(script);
+            var context = await GetExecutionContextAsync().ConfigureAwait(false);
+            return await context.EvaluateExpressionAsync<T>(script).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -144,8 +144,8 @@ namespace PuppeteerSharp
         /// <seealso cref="Page.EvaluateFunctionAsync(string, object[])"/>
         public async Task<dynamic> EvaluateFunctionAsync(string script, params object[] args)
         {
-            var context = await GetExecutionContextAsync();
-            return await context.EvaluateFunctionAsync(script, args);
+            var context = await GetExecutionContextAsync().ConfigureAwait(false);
+            return await context.EvaluateFunctionAsync(script, args).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -163,8 +163,8 @@ namespace PuppeteerSharp
         /// <seealso cref="Page.EvaluateFunctionAsync{T}(string, object[])"/>
         public async Task<T> EvaluateFunctionAsync<T>(string script, params object[] args)
         {
-            var context = await GetExecutionContextAsync();
-            return await context.EvaluateFunctionAsync<T>(script, args);
+            var context = await GetExecutionContextAsync().ConfigureAwait(false);
+            return await context.EvaluateFunctionAsync<T>(script, args).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -180,8 +180,8 @@ namespace PuppeteerSharp
         /// <param name="script">Expression to be evaluated in the <seealso cref="ExecutionContext"/></param>
         public async Task<JSHandle> EvaluateExpressionHandleAsync(string script)
         {
-            var context = await GetExecutionContextAsync();
-            return await context.EvaluateExpressionHandleAsync(script);
+            var context = await GetExecutionContextAsync().ConfigureAwait(false);
+            return await context.EvaluateExpressionHandleAsync(script).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -204,8 +204,8 @@ namespace PuppeteerSharp
         /// <param name="args">Arguments to pass to <paramref name="function"/></param>
         public async Task<JSHandle> EvaluateFunctionHandleAsync(string function, params object[] args)
         {
-            var context = await GetExecutionContextAsync();
-            return await context.EvaluateFunctionHandleAsync(function, args);
+            var context = await GetExecutionContextAsync().ConfigureAwait(false);
+            return await context.EvaluateFunctionHandleAsync(function, args).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -318,8 +318,8 @@ namespace PuppeteerSharp
         /// <seealso cref="Page.QuerySelectorAsync(string)"/>
         public async Task<ElementHandle> QuerySelectorAsync(string selector)
         {
-            var document = await GetDocument();
-            var value = await document.QuerySelectorAsync(selector);
+            var document = await GetDocument().ConfigureAwait(false);
+            var value = await document.QuerySelectorAsync(selector).ConfigureAwait(false);
             return value;
         }
 
@@ -331,8 +331,8 @@ namespace PuppeteerSharp
         /// <seealso cref="Page.QuerySelectorAllAsync(string)"/>
         public async Task<ElementHandle[]> QuerySelectorAllAsync(string selector)
         {
-            var document = await GetDocument();
-            var value = await document.QuerySelectorAllAsync(selector);
+            var document = await GetDocument().ConfigureAwait(false);
+            var value = await document.QuerySelectorAllAsync(selector).ConfigureAwait(false);
             return value;
         }
 
@@ -344,8 +344,8 @@ namespace PuppeteerSharp
         /// <seealso cref="Page.XPathAsync(string)"/>
         public async Task<ElementHandle[]> XPathAsync(string expression)
         {
-            var document = await GetDocument();
-            var value = await document.XPathAsync(expression);
+            var document = await GetDocument().ConfigureAwait(false);
+            var value = await document.XPathAsync(expression).ConfigureAwait(false);
             return value;
         }
 
@@ -388,8 +388,8 @@ namespace PuppeteerSharp
                 var url = options.Url;
                 try
                 {
-                    var context = await GetExecutionContextAsync();
-                    return (await context.EvaluateFunctionHandleAsync(addStyleUrl, url)) as ElementHandle;
+                    var context = await GetExecutionContextAsync().ConfigureAwait(false);
+                    return (await context.EvaluateFunctionHandleAsync(addStyleUrl, url).ConfigureAwait(false)) as ElementHandle;
                 }
                 catch (PuppeteerException)
                 {
@@ -401,14 +401,14 @@ namespace PuppeteerSharp
             {
                 var contents = File.ReadAllText(options.Path, Encoding.UTF8);
                 contents += "//# sourceURL=" + options.Path.Replace("\n", string.Empty);
-                var context = await GetExecutionContextAsync();
-                return (await context.EvaluateFunctionHandleAsync(addStyleContent, contents)) as ElementHandle;
+                var context = await GetExecutionContextAsync().ConfigureAwait(false);
+                return (await context.EvaluateFunctionHandleAsync(addStyleContent, contents).ConfigureAwait(false)) as ElementHandle;
             }
 
             if (!string.IsNullOrEmpty(options.Content))
             {
-                var context = await GetExecutionContextAsync();
-                return (await context.EvaluateFunctionHandleAsync(addStyleContent, options.Content)) as ElementHandle;
+                var context = await GetExecutionContextAsync().ConfigureAwait(false);
+                return (await context.EvaluateFunctionHandleAsync(addStyleContent, options.Content).ConfigureAwait(false)) as ElementHandle;
             }
 
             throw new ArgumentException("Provide options with a `Url`, `Path` or `Content` property");
@@ -450,10 +450,10 @@ namespace PuppeteerSharp
 
             async Task<ElementHandle> AddScriptTagPrivate(string script, string urlOrContent, string type)
             {
-                var context = await GetExecutionContextAsync();
+                var context = await GetExecutionContextAsync().ConfigureAwait(false);
                 return (string.IsNullOrEmpty(type)
-                        ? await context.EvaluateFunctionHandleAsync(script, urlOrContent)
-                        : await context.EvaluateFunctionHandleAsync(script, urlOrContent, type)) as ElementHandle;
+                        ? await context.EvaluateFunctionHandleAsync(script, urlOrContent).ConfigureAwait(false)
+                        : await context.EvaluateFunctionHandleAsync(script, urlOrContent, type).ConfigureAwait(false)) as ElementHandle;
             }
 
             if (!string.IsNullOrEmpty(options.Url))
@@ -461,7 +461,7 @@ namespace PuppeteerSharp
                 var url = options.Url;
                 try
                 {
-                    return await AddScriptTagPrivate(addScriptUrl, url, options.Type);
+                    return await AddScriptTagPrivate(addScriptUrl, url, options.Type).ConfigureAwait(false);
                 }
                 catch (PuppeteerException)
                 {
@@ -473,12 +473,12 @@ namespace PuppeteerSharp
             {
                 var contents = File.ReadAllText(options.Path, Encoding.UTF8);
                 contents += "//# sourceURL=" + options.Path.Replace("\n", string.Empty);
-                return await AddScriptTagPrivate(addScriptContent, contents, options.Type);
+                return await AddScriptTagPrivate(addScriptContent, contents, options.Type).ConfigureAwait(false);
             }
 
             if (!string.IsNullOrEmpty(options.Content))
             {
-                return await AddScriptTagPrivate(addScriptContent, options.Content, options.Type);
+                return await AddScriptTagPrivate(addScriptContent, options.Content, options.Type).ConfigureAwait(false);
             }
 
             throw new ArgumentException("Provide options with a `Url`, `Path` or `Content` property");
@@ -558,7 +558,7 @@ namespace PuppeteerSharp
                     isXPath,
                     options.Visible,
                     options.Hidden
-            }).Task;
+            }).Task.ConfigureAwait(false);
             return handle as ElementHandle;
         }
 
@@ -628,11 +628,11 @@ namespace PuppeteerSharp
             if (_documentCompletionSource == null)
             {
                 _documentCompletionSource = new TaskCompletionSource<ElementHandle>();
-                var context = await GetExecutionContextAsync();
-                var document = await context.EvaluateExpressionHandleAsync("document");
+                var context = await GetExecutionContextAsync().ConfigureAwait(false);
+                var document = await context.EvaluateExpressionHandleAsync("document").ConfigureAwait(false);
                 _documentCompletionSource.SetResult(document as ElementHandle);
             }
-            return await _documentCompletionSource.Task;
+            return await _documentCompletionSource.Task.ConfigureAwait(false);
         }
 
         #endregion

--- a/lib/PuppeteerSharp/Helpers/RemoteObjectHelper.cs
+++ b/lib/PuppeteerSharp/Helpers/RemoteObjectHelper.cs
@@ -62,7 +62,7 @@ namespace PuppeteerSharp.Helpers
                 return;
             try
             {
-                await client.SendAsync("Runtime.releaseObject", new { remoteObject.objectId });
+                await client.SendAsync("Runtime.releaseObject", new { remoteObject.objectId }).ConfigureAwait(false);
             }
             catch (Exception ex)
             {

--- a/lib/PuppeteerSharp/Helpers/TaskQueue.cs
+++ b/lib/PuppeteerSharp/Helpers/TaskQueue.cs
@@ -15,10 +15,10 @@ namespace PuppeteerSharp.Helpers
 
         internal async Task<T> Enqueue<T>(Func<Task<T>> taskGenerator)
         {
-            await _semaphore.WaitAsync();
+            await _semaphore.WaitAsync().ConfigureAwait(false);
             try
             {
-                return await taskGenerator();
+                return await taskGenerator().ConfigureAwait(false);
             }
             finally
             {
@@ -28,10 +28,10 @@ namespace PuppeteerSharp.Helpers
 
         internal async Task Enqueue(Func<Task> taskGenerator)
         {
-            await _semaphore.WaitAsync();
+            await _semaphore.WaitAsync().ConfigureAwait(false);
             try
             {
-                await taskGenerator();
+                await taskGenerator().ConfigureAwait(false);
             }
             finally
             {

--- a/lib/PuppeteerSharp/Input/Keyboard.cs
+++ b/lib/PuppeteerSharp/Input/Keyboard.cs
@@ -31,7 +31,7 @@ namespace PuppeteerSharp.Input
         /// After the key is pressed once, subsequent calls to <see cref="DownAsync(string, DownOptions)"/> will have <see href="https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/repeat">repeat</see> set to <c>true</c>. To release the key, use <see cref="UpAsync(string)"/>
         /// </remarks>
         /// <returns>Task</returns>
-        public async Task DownAsync(string key, DownOptions options = null)
+        public Task DownAsync(string key, DownOptions options = null)
         {
             var description = KeyDescriptionForString(key);
 
@@ -41,7 +41,7 @@ namespace PuppeteerSharp.Input
 
             var text = options?.Text == null ? description.Text : options.Text;
 
-            await _client.SendAsync("Input.dispatchKeyEvent", new Dictionary<string, object>(){
+            return _client.SendAsync("Input.dispatchKeyEvent", new Dictionary<string, object>(){
                 {"type", text != null ? "keyDown" : "rawKeyDown"},
                 {"modifiers", Modifiers},
                 {"windowsVirtualKeyCode", description.KeyCode},
@@ -60,14 +60,14 @@ namespace PuppeteerSharp.Input
         /// </summary>
         /// <param name="key">Name of key to release, such as `ArrowLeft`. See <see cref="KeyDefinitions"/> for a list of all key names.</param>
         /// <returns>Task</returns>
-        public async Task UpAsync(string key)
+        public Task UpAsync(string key)
         {
             var description = KeyDescriptionForString(key);
 
             Modifiers &= ~ModifierBit(key);
             _pressedKeys.Remove(description.Code);
 
-            await _client.SendAsync("Input.dispatchKeyEvent", new Dictionary<string, object>(){
+            return _client.SendAsync("Input.dispatchKeyEvent", new Dictionary<string, object>(){
                 {"type", "keyUp"},
                 {"modifiers", Modifiers},
                 {"key", description.Key},
@@ -82,9 +82,9 @@ namespace PuppeteerSharp.Input
         /// </summary>
         /// <param name="charText">Character to send into the page</param>
         /// <returns>Task</returns>
-        public async Task SendCharacterAsync(string charText)
+        public Task SendCharacterAsync(string charText)
         {
-            await _client.SendAsync("Input.dispatchKeyEvent", new Dictionary<string, object>(){
+            return _client.SendAsync("Input.dispatchKeyEvent", new Dictionary<string, object>(){
                 {"type", "char"},
                 {"modifiers", Modifiers},
                 {"text", charText },
@@ -113,15 +113,15 @@ namespace PuppeteerSharp.Input
             {
                 if (KeyDefinitions.ContainsKey(letter.ToString()))
                 {
-                    await PressAsync(letter.ToString(), new PressOptions { Delay = delay });
+                    await PressAsync(letter.ToString(), new PressOptions { Delay = delay }).ConfigureAwait(false);
                 }
                 else
                 {
-                    await SendCharacterAsync(letter.ToString());
+                    await SendCharacterAsync(letter.ToString()).ConfigureAwait(false);
                 }
                 if (delay > 0)
                 {
-                    await Task.Delay(delay);
+                    await Task.Delay(delay).ConfigureAwait(false);
                 }
             }
         }
@@ -138,12 +138,12 @@ namespace PuppeteerSharp.Input
         /// <returns>Task</returns>
         public async Task PressAsync(string key, PressOptions options = null)
         {
-            await DownAsync(key, options);
+            await DownAsync(key, options).ConfigureAwait(false);
             if (options?.Delay > 0)
             {
-                await Task.Delay((int)options.Delay);
+                await Task.Delay((int)options.Delay).ConfigureAwait(false);
             }
-            await UpAsync(key);
+            await UpAsync(key).ConfigureAwait(false);
         }
 
         private int ModifierBit(string key)

--- a/lib/PuppeteerSharp/Input/Mouse.cs
+++ b/lib/PuppeteerSharp/Input/Mouse.cs
@@ -51,7 +51,7 @@ namespace PuppeteerSharp.Input
                     {"x", fromX + ((_x - fromX) * ((decimal)i / steps))},
                     {"y", fromY + ((_y - fromY) * ((decimal)i / steps))},
                     {"modifiers", _keyboard.Modifiers}
-                });
+                }).ConfigureAwait(false);
             }
         }
 
@@ -66,14 +66,14 @@ namespace PuppeteerSharp.Input
         {
             options = options ?? new ClickOptions();
 
-            await MoveAsync(x, y);
-            await DownAsync(options);
+            await MoveAsync(x, y).ConfigureAwait(false);
+            await DownAsync(options).ConfigureAwait(false);
 
             if (options.Delay > 0)
             {
-                await Task.Delay(options.Delay);
+                await Task.Delay(options.Delay).ConfigureAwait(false);
             }
-            await UpAsync(options);
+            await UpAsync(options).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -81,13 +81,13 @@ namespace PuppeteerSharp.Input
         /// </summary>
         /// <param name="options"></param>
         /// <returns>Task</returns>
-        public async Task DownAsync(ClickOptions options = null)
+        public Task DownAsync(ClickOptions options = null)
         {
             options = options ?? new ClickOptions();
 
             _button = options.Button;
 
-            await _client.SendAsync("Input.dispatchMouseEvent", new Dictionary<string, object>(){
+            return _client.SendAsync("Input.dispatchMouseEvent", new Dictionary<string, object>(){
                 {"type", "mousePressed"},
                 {"button", _button},
                 {"x", _x},
@@ -102,13 +102,13 @@ namespace PuppeteerSharp.Input
         /// </summary>
         /// <param name="options"></param>
         /// <returns>Task</returns>
-        public async Task UpAsync(ClickOptions options = null)
+        public Task UpAsync(ClickOptions options = null)
         {
             options = options ?? new ClickOptions();
 
             _button = MouseButton.None;
 
-            await _client.SendAsync("Input.dispatchMouseEvent", new Dictionary<string, object>(){
+            return _client.SendAsync("Input.dispatchMouseEvent", new Dictionary<string, object>(){
                 {"type", "mouseReleased"},
                 {"button", options.Button},
                 {"x", _x},

--- a/lib/PuppeteerSharp/Input/Touchscreen.cs
+++ b/lib/PuppeteerSharp/Input/Touchscreen.cs
@@ -38,7 +38,7 @@ namespace PuppeteerSharp.Input
             {
                 expression = "new Promise(x => requestAnimationFrame(() => requestAnimationFrame(x)))",
                 awaitPromise = true
-            });
+            }).ConfigureAwait(false);
 
             var touchPoints = new[] { new { x = Math.Round(x), y = Math.Round(y) } };
             await _client.SendAsync("Input.dispatchTouchEvent", new
@@ -46,13 +46,13 @@ namespace PuppeteerSharp.Input
                 type = "touchStart",
                 touchPoints,
                 modifiers = _keyboard.Modifiers
-            });
+            }).ConfigureAwait(false);
             await _client.SendAsync("Input.dispatchTouchEvent", new
             {
                 type = "touchEnd",
                 touchPoints = Array.Empty<object>(),
                 modifiers = _keyboard.Modifiers
-            });
+            }).ConfigureAwait(false);
         }
     }
 }

--- a/lib/PuppeteerSharp/JSHandle.cs
+++ b/lib/PuppeteerSharp/JSHandle.cs
@@ -57,10 +57,10 @@ namespace PuppeteerSharp
               const result = { __proto__: null};
               result[propertyName] = object[propertyName];
               return result;
-            }", this, propertyName);
-            var properties = await objectHandle.GetPropertiesAsync();
+            }", this, propertyName).ConfigureAwait(false);
+            var properties = await objectHandle.GetPropertiesAsync().ConfigureAwait(false);
             properties.TryGetValue(propertyName, out var result);
-            await objectHandle.DisposeAsync();
+            await objectHandle.DisposeAsync().ConfigureAwait(false);
             return result;
         }
 
@@ -83,7 +83,7 @@ namespace PuppeteerSharp
             {
                 objectId = RemoteObject.objectId.ToString(),
                 ownProperties = true
-            });
+            }).ConfigureAwait(false);
             var result = new Dictionary<string, JSHandle>();
             foreach (var property in response.result)
             {
@@ -104,7 +104,7 @@ namespace PuppeteerSharp
         /// <remarks>
         /// The method will return an empty JSON if the referenced object is not stringifiable. It will throw an error if the object has circular references
         /// </remarks>
-        public async Task<object> JsonValueAsync() => await JsonValueAsync<object>();
+        public async Task<object> JsonValueAsync() => await JsonValueAsync<object>().ConfigureAwait(false);
 
         /// <summary>
         /// Returns a JSON representation of the object
@@ -124,7 +124,7 @@ namespace PuppeteerSharp
                     ["objectId"] = RemoteObject.objectId,
                     ["returnByValue"] = true,
                     ["awaitPromise"] = true
-                });
+                }).ConfigureAwait(false);
                 return (T)RemoteObjectHelper.ValueFromRemoteObject<T>(response.result);
             }
 
@@ -143,7 +143,7 @@ namespace PuppeteerSharp
             }
 
             Disposed = true;
-            await RemoteObjectHelper.ReleaseObject(Client, RemoteObject, Logger);
+            await RemoteObjectHelper.ReleaseObject(Client, RemoteObject, Logger).ConfigureAwait(false);
         }
 
         /// <inheritdoc/>

--- a/lib/PuppeteerSharp/Launcher.cs
+++ b/lib/PuppeteerSharp/Launcher.cs
@@ -114,10 +114,10 @@ namespace PuppeteerSharp
             try
             {
                 var connectionDelay = options.SlowMo;
-                var browserWSEndpoint = await WaitForEndpoint(_chromeProcess, options.Timeout);
+                var browserWSEndpoint = await WaitForEndpoint(_chromeProcess, options.Timeout).ConfigureAwait(false);
                 var keepAliveInterval = 0;
 
-                _connection = await Connection.Create(browserWSEndpoint, connectionDelay, keepAliveInterval, _loggerFactory);
+                _connection = await Connection.Create(browserWSEndpoint, connectionDelay, keepAliveInterval, _loggerFactory).ConfigureAwait(false);
                 _processLoaded = true;
 
                 if (options.LogProcess)
@@ -125,7 +125,7 @@ namespace PuppeteerSharp
                     _logger.LogInformation("Process Count: {ProcessCount}", Interlocked.Increment(ref _processCount));
                 }
 
-                return await Browser.CreateAsync(_connection, options, _chromeProcess, GracefullyCloseChrome);
+                return await Browser.CreateAsync(_connection, options, _chromeProcess, GracefullyCloseChrome).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -152,7 +152,7 @@ namespace PuppeteerSharp
                 var connectionDelay = options.SlowMo;
                 var keepAliveInterval = 0;
 
-                _connection = await Connection.Create(options.BrowserWSEndpoint, connectionDelay, keepAliveInterval, _loggerFactory);
+                _connection = await Connection.Create(options.BrowserWSEndpoint, connectionDelay, keepAliveInterval, _loggerFactory).ConfigureAwait(false);
 
                 return await Browser.CreateAsync(_connection, options, null, () =>
                 {
@@ -165,7 +165,7 @@ namespace PuppeteerSharp
                         _logger.LogError(ex, ex.Message);
                     }
                     return null;
-                });
+                }).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -213,7 +213,7 @@ namespace PuppeteerSharp
                         throw;
                     }
 
-                    await Task.Delay(delay.Value);
+                    await Task.Delay(delay.Value).ConfigureAwait(false);
                 }
             }
         }
@@ -255,7 +255,7 @@ namespace PuppeteerSharp
 
             _chromeProcess.Exited += async (sender, e) =>
             {
-                await AfterProcessExit();
+                await AfterProcessExit().ConfigureAwait(false);
             };
 
             _chromeProcess.ErrorDataReceived += (sender, e) =>
@@ -415,7 +415,7 @@ namespace PuppeteerSharp
 
             if (_temporaryUserDataDir != null)
             {
-                await TryDeleteUserDataDir();
+                await TryDeleteUserDataDir().ConfigureAwait(false);
             }
 
             if (_waitForChromeToClose.Task.Status != TaskStatus.RanToCompletion)
@@ -429,13 +429,13 @@ namespace PuppeteerSharp
             if (!string.IsNullOrEmpty(_temporaryUserDataDir))
             {
                 KillChrome();
-                await AfterProcessExit();
+                await AfterProcessExit().ConfigureAwait(false);
             }
             else if (_connection != null)
             {
                 try
                 {
-                    await _connection.SendAsync("Browser.close", null);
+                    await _connection.SendAsync("Browser.close", null).ConfigureAwait(false);
                 }
                 catch (Exception ex)
                 {
@@ -444,7 +444,7 @@ namespace PuppeteerSharp
                 }
             }
 
-            await _waitForChromeToClose.Task;
+            await _waitForChromeToClose.Task.ConfigureAwait(false);
         }
 
         private void KillChrome()

--- a/lib/PuppeteerSharp/NavigatorWatcher.cs
+++ b/lib/PuppeteerSharp/NavigatorWatcher.cs
@@ -134,11 +134,11 @@ namespace PuppeteerSharp
 
             if (_timeout == 0)
             {
-                await Task.Delay(-1);
+                await Task.Delay(-1).ConfigureAwait(false);
             }
             else
             {
-                await Task.Delay(_timeout);
+                await Task.Delay(_timeout).ConfigureAwait(false);
                 throw new NavigationException($"Navigation Timeout Exceeded: {_timeout}ms exceeded");
             }
         }

--- a/lib/PuppeteerSharp/NetworkManager.cs
+++ b/lib/PuppeteerSharp/NetworkManager.cs
@@ -46,13 +46,13 @@ namespace PuppeteerSharp
 
         #region Public Methods
 
-        internal async Task AuthenticateAsync(Credentials credentials)
+        internal Task AuthenticateAsync(Credentials credentials)
         {
             _credentials = credentials;
-            await UpdateProtocolRequestInterceptionAsync();
+            return UpdateProtocolRequestInterceptionAsync();
         }
 
-        internal async Task SetExtraHTTPHeadersAsync(Dictionary<string, string> extraHTTPHeaders)
+        internal Task SetExtraHTTPHeadersAsync(Dictionary<string, string> extraHTTPHeaders)
         {
             _extraHTTPHeaders = new Dictionary<string, string>();
 
@@ -60,7 +60,7 @@ namespace PuppeteerSharp
             {
                 _extraHTTPHeaders[item.Key.ToLower()] = item.Value;
             }
-            await _client.SendAsync("Network.setExtraHTTPHeaders", new Dictionary<string, object>
+            return _client.SendAsync("Network.setExtraHTTPHeaders", new Dictionary<string, object>
             {
                 {"headers", _extraHTTPHeaders}
             });
@@ -78,7 +78,7 @@ namespace PuppeteerSharp
                     { "latency", 0},
                     { "downloadThroughput", -1},
                     { "uploadThroughput", -1}
-                });
+                }).ConfigureAwait(false);
             }
         }
 
@@ -88,10 +88,10 @@ namespace PuppeteerSharp
                 { "userAgent", userAgent }
             });
 
-        internal async Task SetRequestInterceptionAsync(bool value)
+        internal Task SetRequestInterceptionAsync(bool value)
         {
             _userRequestInterceptionEnabled = value;
-            await UpdateProtocolRequestInterceptionAsync();
+            return UpdateProtocolRequestInterceptionAsync();
         }
 
         #endregion
@@ -106,7 +106,7 @@ namespace PuppeteerSharp
                     OnRequestWillBeSent(e.MessageData.ToObject<RequestWillBeSentResponse>());
                     break;
                 case "Network.requestIntercepted":
-                    await OnRequestInterceptedAsync(e.MessageData.ToObject<RequestInterceptedResponse>());
+                    await OnRequestInterceptedAsync(e.MessageData.ToObject<RequestInterceptedResponse>()).ConfigureAwait(false);
                     break;
                 case "Network.requestServedFromCache":
                     OnRequestServedFromCache(e.MessageData.ToObject<RequestServedFromCacheResponse>());
@@ -217,7 +217,7 @@ namespace PuppeteerSharp
                                 password = credentials.Password
                             }
                         }
-                    });
+                    }).ConfigureAwait(false);
                 }
                 catch (PuppeteerException ex)
                 {
@@ -232,7 +232,7 @@ namespace PuppeteerSharp
                     await _client.SendAsync("Network.continueInterceptedRequest", new Dictionary<string, object>
                     {
                         { "interceptionId", e.InterceptionId}
-                    });
+                    }).ConfigureAwait(false);
                 }
                 catch (PuppeteerException ex)
                 {
@@ -451,7 +451,7 @@ namespace PuppeteerSharp
                 {
                     { "patterns", patterns}
                 })
-            );
+            ).ConfigureAwait(false);
         }
         #endregion
     }

--- a/lib/PuppeteerSharp/Page.cs
+++ b/lib/PuppeteerSharp/Page.cs
@@ -1717,13 +1717,12 @@ namespace PuppeteerSharp
                 var result = binding.DynamicInvoke(args);
                 if (result is Task taskResult)
                 {
+                    await taskResult.ConfigureAwait(false);
+
                     if (taskResult.GetType().IsGenericType)
                     {
-                        result = await (dynamic)taskResult.ConfigureAwait(false);
-                    }
-                    else
-                    {
-                        await taskResult.ConfigureAwait(false);
+                        // the task is already awaited and therefore the call to property Result will not deadlock
+                        result = ((dynamic)taskResult).Result;
                     }
                 }
 

--- a/lib/PuppeteerSharp/Page.cs
+++ b/lib/PuppeteerSharp/Page.cs
@@ -279,7 +279,7 @@ namespace PuppeteerSharp
         /// </remarks>
         public async Task<Dictionary<string, decimal>> MetricsAsync()
         {
-            var response = await Client.SendAsync<PerformanceGetMetricsResponse>("Performance.getMetrics");
+            var response = await Client.SendAsync<PerformanceGetMetricsResponse>("Performance.getMetrics").ConfigureAwait(false);
             return BuildMetricsObject(response.Metrics);
         }
 
@@ -291,13 +291,13 @@ namespace PuppeteerSharp
         /// <returns>Task which resolves when the element matching <paramref name="selector"/> is successfully tapped</returns>
         public async Task TapAsync(string selector)
         {
-            var handle = await QuerySelectorAsync(selector);
+            var handle = await QuerySelectorAsync(selector).ConfigureAwait(false);
             if (handle == null)
             {
                 throw new SelectorException($"No node found for selector: {selector}", selector);
             }
-            await handle.TapAsync();
-            await handle.DisposeAsync();
+            await handle.TapAsync().ConfigureAwait(false);
+            await handle.DisposeAsync().ConfigureAwait(false);
         }
 
         /// <summary>
@@ -350,8 +350,8 @@ namespace PuppeteerSharp
         /// <returns>Task which resolves to script return value</returns>
         public async Task<JSHandle> EvaluateExpressionHandleAsync(string script)
         {
-            var context = await MainFrame.GetExecutionContextAsync();
-            return await context.EvaluateExpressionHandleAsync(script);
+            var context = await MainFrame.GetExecutionContextAsync().ConfigureAwait(false);
+            return await context.EvaluateExpressionHandleAsync(script).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -366,8 +366,8 @@ namespace PuppeteerSharp
         /// <returns>Task which resolves to script return value</returns>
         public async Task<JSHandle> EvaluateFunctionHandleAsync(string pageFunction, params object[] args)
         {
-            var context = await MainFrame.GetExecutionContextAsync();
-            return await context.EvaluateFunctionHandleAsync(pageFunction, args);
+            var context = await MainFrame.GetExecutionContextAsync().ConfigureAwait(false);
+            return await context.EvaluateFunctionHandleAsync(pageFunction, args).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -406,8 +406,8 @@ namespace PuppeteerSharp
         /// <param name="prototypeHandle">A handle to the object prototype.</param>
         public async Task<JSHandle> QueryObjectsAsync(JSHandle prototypeHandle)
         {
-            var context = await MainFrame.GetExecutionContextAsync();
-            return await context.QueryObjectsAsync(prototypeHandle);
+            var context = await MainFrame.GetExecutionContextAsync().ConfigureAwait(false);
+            return await context.QueryObjectsAsync(prototypeHandle).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -440,7 +440,7 @@ namespace PuppeteerSharp
             var response = await Client.SendAsync("Network.getCookies", new Dictionary<string, object>
             {
                 { "urls", urls.Length > 0 ? urls : new string[] { Url } }
-            });
+            }).ConfigureAwait(false);
             return response.cookies.ToObject<CookieParam[]>();
         }
 
@@ -463,14 +463,14 @@ namespace PuppeteerSharp
                 }
             }
 
-            await DeleteCookieAsync(cookies);
+            await DeleteCookieAsync(cookies).ConfigureAwait(false);
 
             if (cookies.Length > 0)
             {
                 await Client.SendAsync("Network.setCookies", new Dictionary<string, object>
                 {
                     { "cookies", cookies}
-                });
+                }).ConfigureAwait(false);
             }
         }
 
@@ -488,7 +488,7 @@ namespace PuppeteerSharp
                 {
                     cookie.Url = pageURL;
                 }
-                await Client.SendAsync("Network.deleteCookies", cookie);
+                await Client.SendAsync("Network.deleteCookies", cookie).ConfigureAwait(false);
             }
         }
 
@@ -678,7 +678,7 @@ namespace PuppeteerSharp
 
             await Task.WhenAny(
                 watcher.NavigationTask,
-                navigateTask);
+                navigateTask).ConfigureAwait(false);
 
             AggregateException exception = null;
 
@@ -696,7 +696,7 @@ namespace PuppeteerSharp
             {
                 await Task.WhenAll(
                     watcher.NavigationTask,
-                    navigateTask);
+                    navigateTask).ConfigureAwait(false);
                 exception = navigateTask.Exception ?? watcher.NavigationTask.Result.Exception;
             }
 
@@ -745,11 +745,11 @@ namespace PuppeteerSharp
         /// </remarks>
         public async Task PdfAsync(string file, PdfOptions options)
         {
-            var data = await PdfDataAsync(options);
+            var data = await PdfDataAsync(options).ConfigureAwait(false);
 
             using (var fs = File.OpenWrite(file))
             {
-                await fs.WriteAsync(data, 0, data.Length);
+                await fs.WriteAsync(data, 0, data.Length).ConfigureAwait(false);
             }
         }
 
@@ -771,7 +771,7 @@ namespace PuppeteerSharp
         /// Generating a pdf is currently only supported in Chrome headless
         /// </remarks>
         public async Task<Stream> PdfStreamAsync(PdfOptions options)
-            => new MemoryStream(await PdfDataAsync(options));
+            => new MemoryStream(await PdfDataAsync(options).ConfigureAwait(false));
 
         /// <summary>
         /// Generates a pdf of the page with <see cref="MediaType.Print"/> css media. To generate a pdf with <see cref="MediaType.Screen"/> media call <see cref="EmulateMediaAsync(MediaType)"/> with <see cref="MediaType.Screen"/>
@@ -832,7 +832,7 @@ namespace PuppeteerSharp
                 marginLeft,
                 marginRight,
                 pageRanges = options.PageRanges
-            });
+            }).ConfigureAwait(false);
 
             var buffer = Convert.FromBase64String(result.GetValue("data").Value<string>());
             return buffer;
@@ -874,12 +874,12 @@ namespace PuppeteerSharp
         /// <param name="viewport">Viewport options.</param>
         public async Task SetViewportAsync(ViewPortOptions viewport)
         {
-            var needsReload = await _emulationManager.EmulateViewport(viewport);
+            var needsReload = await _emulationManager.EmulateViewport(viewport).ConfigureAwait(false);
             Viewport = viewport;
 
             if (needsReload)
             {
-                await ReloadAsync();
+                await ReloadAsync().ConfigureAwait(false);
             }
         }
 
@@ -921,11 +921,11 @@ namespace PuppeteerSharp
             {
                 options.Type = ScreenshotOptions.GetScreenshotTypeFromFile(file);
             }
-            var data = await ScreenshotDataAsync(options);
+            var data = await ScreenshotDataAsync(options).ConfigureAwait(false);
 
             using (var fs = new FileStream(file, FileMode.Create, FileAccess.Write))
             {
-                await fs.WriteAsync(data, 0, data.Length);
+                await fs.WriteAsync(data, 0, data.Length).ConfigureAwait(false);
             }
         }
 
@@ -941,7 +941,7 @@ namespace PuppeteerSharp
         /// <returns>Task which resolves to a <see cref="Stream"/> containing the image data.</returns>
         /// <param name="options">Screenshot options.</param>
         public async Task<Stream> ScreenshotStreamAsync(ScreenshotOptions options)
-            => new MemoryStream(await ScreenshotDataAsync(options));
+            => new MemoryStream(await ScreenshotDataAsync(options).ConfigureAwait(false));
 
         /// <summary>
         /// Takes a screenshot of the page
@@ -954,7 +954,7 @@ namespace PuppeteerSharp
         /// </summary>
         /// <returns>Task which resolves to a <see cref="byte"/>[] containing the image data.</returns>
         /// <param name="options">Screenshot options.</param>
-        public async Task<byte[]> ScreenshotDataAsync(ScreenshotOptions options)
+        public Task<byte[]> ScreenshotDataAsync(ScreenshotOptions options)
         {
             var screenshotType = options.Type;
 
@@ -981,7 +981,7 @@ namespace PuppeteerSharp
                 throw new ArgumentException("options.clip and options.fullPage are exclusive");
             }
 
-            return await _screenshotTaskQueue.Enqueue(() => PerformScreenshot(screenshotType.Value, options));
+            return _screenshotTaskQueue.Enqueue(() => PerformScreenshot(screenshotType.Value, options));
         }
 
         /// <summary>
@@ -1037,13 +1037,13 @@ namespace PuppeteerSharp
         /// <returns>Task which resolves when the element matching <paramref name="selector"/> is successfully clicked</returns>
         public async Task ClickAsync(string selector, ClickOptions options = null)
         {
-            var handle = await QuerySelectorAsync(selector);
+            var handle = await QuerySelectorAsync(selector).ConfigureAwait(false);
             if (handle == null)
             {
                 throw new SelectorException($"No node found for selector: {selector}", selector);
             }
-            await handle.ClickAsync(options);
-            await handle.DisposeAsync();
+            await handle.ClickAsync(options).ConfigureAwait(false);
+            await handle.DisposeAsync().ConfigureAwait(false);
         }
 
         /// <summary>
@@ -1054,13 +1054,13 @@ namespace PuppeteerSharp
         /// <returns>Task which resolves when the element matching <paramref name="selector"/> is successfully hovered</returns>
         public async Task HoverAsync(string selector)
         {
-            var handle = await QuerySelectorAsync(selector);
+            var handle = await QuerySelectorAsync(selector).ConfigureAwait(false);
             if (handle == null)
             {
                 throw new SelectorException($"No node found for selector: {selector}", selector);
             }
-            await handle.HoverAsync();
-            await handle.DisposeAsync();
+            await handle.HoverAsync().ConfigureAwait(false);
+            await handle.DisposeAsync().ConfigureAwait(false);
         }
 
         /// <summary>
@@ -1071,13 +1071,13 @@ namespace PuppeteerSharp
         /// <returns>Task which resolves when the element matching <paramref name="selector"/> is successfully focused</returns>
         public async Task FocusAsync(string selector)
         {
-            var handle = await QuerySelectorAsync(selector);
+            var handle = await QuerySelectorAsync(selector).ConfigureAwait(false);
             if (handle == null)
             {
                 throw new SelectorException($"No node found for selector: {selector}", selector);
             }
-            await handle.FocusAsync();
-            await handle.DisposeAsync();
+            await handle.FocusAsync().ConfigureAwait(false);
+            await handle.DisposeAsync().ConfigureAwait(false);
         }
 
         /// <summary>
@@ -1173,7 +1173,7 @@ namespace PuppeteerSharp
             await Task.WhenAll(
               navigationTask,
               Client.SendAsync("Page.reload")
-            );
+            ).ConfigureAwait(false);
 
             return navigationTask.Result;
         }
@@ -1220,13 +1220,13 @@ namespace PuppeteerSharp
         /// <returns>Task</returns>
         public async Task TypeAsync(string selector, string text, TypeOptions options = null)
         {
-            var handle = await QuerySelectorAsync(selector);
+            var handle = await QuerySelectorAsync(selector).ConfigureAwait(false);
             if (handle == null)
             {
                 throw new SelectorException($"No node found for selector: {selector}", selector);
             }
-            await handle.TypeAsync(text, options);
-            await handle.DisposeAsync();
+            await handle.TypeAsync(text, options).ConfigureAwait(false);
+            await handle.DisposeAsync().ConfigureAwait(false);
         }
 
         /// <summary>
@@ -1336,7 +1336,7 @@ namespace PuppeteerSharp
 
             _networkManager.Response += createResponseEventListener;
 
-            await watcher.NavigationTask;
+            await watcher.NavigationTask.ConfigureAwait(false);
 
             _networkManager.Response -= createResponseEventListener;
 
@@ -1376,8 +1376,8 @@ namespace PuppeteerSharp
             bool setDefaultViewPort,
             TaskQueue screenshotTaskQueue)
         {
-            await client.SendAsync("Page.enable", null);
-            dynamic result = await client.SendAsync("Page.getFrameTree");
+            await client.SendAsync("Page.enable", null).ConfigureAwait(false);
+            dynamic result = await client.SendAsync("Page.getFrameTree").ConfigureAwait(false);
             var page = new Page(client, target, new FrameTree(result.frameTree), ignoreHTTPSErrors, screenshotTaskQueue);
 
             await Task.WhenAll(
@@ -1390,14 +1390,14 @@ namespace PuppeteerSharp
                 client.SendAsync("Security.enable", null),
                 client.SendAsync("Performance.enable", null),
                 client.SendAsync("Log.enable", null)
-            );
+            ).ConfigureAwait(false);
 
             if (ignoreHTTPSErrors)
             {
                 await client.SendAsync("Security.setOverrideCertificateErrors", new Dictionary<string, object>
                 {
                     {"override", true}
-                });
+                }).ConfigureAwait(false);
             }
 
             if (setDefaultViewPort)
@@ -1406,14 +1406,14 @@ namespace PuppeteerSharp
                 {
                     Width = 800,
                     Height = 600
-                });
+                }).ConfigureAwait(false);
             }
             return page;
         }
 
         private async Task<Response> GoAsync(int delta, NavigationOptions options)
         {
-            var history = await Client.SendAsync<PageGetNavigationHistoryResponse>("Page.getNavigationHistory");
+            var history = await Client.SendAsync<PageGetNavigationHistoryResponse>("Page.getNavigationHistory").ConfigureAwait(false);
 
             if (history.Entries.Count <= history.CurrentIndex + delta)
             {
@@ -1428,7 +1428,7 @@ namespace PuppeteerSharp
                 {
                     entryId = entry.Id
                 })
-            );
+            ).ConfigureAwait(false);
 
             return waitTask.Result;
         }
@@ -1453,7 +1453,7 @@ namespace PuppeteerSharp
             await Client.SendAsync("Target.activateTarget", new
             {
                 targetId = Target.TargetId
-            });
+            }).ConfigureAwait(false);
 
             var clip = options.Clip?.Clone();
             if (clip != null)
@@ -1463,7 +1463,7 @@ namespace PuppeteerSharp
 
             if (options != null && options.FullPage)
             {
-                dynamic metrics = await Client.SendAsync("Page.getLayoutMetrics");
+                dynamic metrics = await Client.SendAsync("Page.getLayoutMetrics").ConfigureAwait(false);
                 var width = Convert.ToInt32(Math.Ceiling(Convert.ToDecimal(metrics.contentSize.width.Value)));
                 var height = Convert.ToInt32(Math.Ceiling(Convert.ToDecimal(metrics.contentSize.height.Value)));
 
@@ -1499,7 +1499,7 @@ namespace PuppeteerSharp
                     height,
                     deviceScaleFactor,
                     screenOrientation
-                });
+                }).ConfigureAwait(false);
             }
 
             if (options != null && options.OmitBackground)
@@ -1513,7 +1513,7 @@ namespace PuppeteerSharp
                         b = 0,
                         a = 0
                     }
-                });
+                }).ConfigureAwait(false);
             }
 
             dynamic screenMessage = new ExpandoObject();
@@ -1530,16 +1530,16 @@ namespace PuppeteerSharp
                 screenMessage.clip = clip;
             }
 
-            JObject result = await Client.SendAsync("Page.captureScreenshot", screenMessage);
+            JObject result = await Client.SendAsync("Page.captureScreenshot", screenMessage).ConfigureAwait(false);
 
             if (options != null && options.OmitBackground)
             {
-                await Client.SendAsync("Emulation.setDefaultBackgroundColorOverride");
+                await Client.SendAsync("Emulation.setDefaultBackgroundColorOverride").ConfigureAwait(false);
             }
 
             if (options != null && options.FullPage)
             {
-                await SetViewportAsync(Viewport);
+                await SetViewportAsync(Viewport).ConfigureAwait(false);
             }
 
             var buffer = Convert.FromBase64String(result.GetValue("data").Value<string>());
@@ -1602,7 +1602,7 @@ namespace PuppeteerSharp
                     Load?.Invoke(this, EventArgs.Empty);
                     break;
                 case "Runtime.consoleAPICalled":
-                    await OnConsoleAPI(e.MessageData.ToObject<PageConsoleResponse>());
+                    await OnConsoleAPI(e.MessageData.ToObject<PageConsoleResponse>()).ConfigureAwait(false);
                     break;
                 case "Page.javascriptDialogOpening":
                     OnDialog(e.MessageData.ToObject<PageJavascriptDialogOpeningResponse>());
@@ -1611,7 +1611,7 @@ namespace PuppeteerSharp
                     HandleException(e.MessageData.SelectToken("exceptionDetails").ToObject<EvaluateExceptionDetails>());
                     break;
                 case "Security.certificateError":
-                    await OnCertificateError(e.MessageData.ToObject<CertificateErrorResponse>());
+                    await OnCertificateError(e.MessageData.ToObject<CertificateErrorResponse>()).ConfigureAwait(false);
                     break;
                 case "Inspector.targetCrashed":
                     OnTargetCrashed();
@@ -1660,7 +1660,7 @@ namespace PuppeteerSharp
                     {
                         {"eventId", e.EventId },
                         {"action", "continue"}
-                    });
+                    }).ConfigureAwait(false);
                 }
                 catch (PuppeteerException ex)
                 {
@@ -1719,11 +1719,11 @@ namespace PuppeteerSharp
                 {
                     if (taskResult.GetType().IsGenericType)
                     {
-                        result = await (dynamic)taskResult;
+                        result = await (dynamic)taskResult.ConfigureAwait(false);
                     }
                     else
                     {
-                        await taskResult;
+                        await taskResult.ConfigureAwait(false);
                     }
                 }
 
@@ -1743,7 +1743,7 @@ namespace PuppeteerSharp
             {
                 foreach (var arg in message.Args)
                 {
-                    await RemoteObjectHelper.ReleaseObject(Client, arg, _logger);
+                    await RemoteObjectHelper.ReleaseObject(Client, arg, _logger).ConfigureAwait(false);
                 }
 
                 return;
@@ -1786,7 +1786,7 @@ namespace PuppeteerSharp
                 };
             }";
             var expression = EvaluationString(addPageBinding, name);
-            await Client.SendAsync("Page.addScriptToEvaluateOnNewDocument", new { source = expression });
+            await Client.SendAsync("Page.addScriptToEvaluateOnNewDocument", new { source = expression }).ConfigureAwait(false);
 
             await Task.WhenAll(Frames.Select(frame => frame.EvaluateExpressionAsync(expression)
                 .ContinueWith(task =>
@@ -1795,7 +1795,7 @@ namespace PuppeteerSharp
                     {
                         _logger.LogError(task.Exception.ToString());
                     }
-                })));
+                }))).ConfigureAwait(false);
         }
 
         private async Task Navigate(CDPSession client, string url, string referrer)
@@ -1804,7 +1804,7 @@ namespace PuppeteerSharp
             {
                 url,
                 referrer = referrer ?? string.Empty
-            });
+            }).ConfigureAwait(false);
 
             if (response.errorText != null)
             {

--- a/lib/PuppeteerSharp/PageCoverage/CSSCoverage.cs
+++ b/lib/PuppeteerSharp/PageCoverage/CSSCoverage.cs
@@ -27,7 +27,7 @@ namespace PuppeteerSharp.PageCoverage
             _resetOnNavigation = false;
         }
 
-        internal async Task StartAsync(CoverageStartOptions options)
+        internal Task StartAsync(CoverageStartOptions options)
         {
             if (_enabled)
             {
@@ -41,7 +41,7 @@ namespace PuppeteerSharp.PageCoverage
 
             _client.MessageReceived += client_MessageReceived;
 
-            await Task.WhenAll(
+            return Task.WhenAll(
                 _client.SendAsync("DOM.enable"),
                 _client.SendAsync("CSS.enable"),
                 _client.SendAsync("CSS.startRuleUsageTracking")
@@ -61,7 +61,7 @@ namespace PuppeteerSharp.PageCoverage
                 ruleTrackingResponseTask,
                 _client.SendAsync("CSS.disable"),
                 _client.SendAsync("DOM.disable")
-           );
+           ).ConfigureAwait(false);
             _client.MessageReceived -= client_MessageReceived;
 
             var styleSheetIdToCoverage = new Dictionary<string, List<CoverageResponseRange>>();
@@ -103,7 +103,7 @@ namespace PuppeteerSharp.PageCoverage
             switch (e.MessageID)
             {
                 case "CSS.styleSheetAdded":
-                    await OnStyleSheetAdded(e.MessageData.ToObject<CSSStyleSheetAddedResponse>());
+                    await OnStyleSheetAdded(e.MessageData.ToObject<CSSStyleSheetAddedResponse>()).ConfigureAwait(false);
                     break;
                 case "Runtime.executionContextsCleared":
                     OnExecutionContextsCleared();
@@ -123,7 +123,7 @@ namespace PuppeteerSharp.PageCoverage
                 var response = await _client.SendAsync("CSS.getStyleSheetText", new
                 {
                     styleSheetId = styleSheetAddedResponse.Header.StyleSheetId
-                });
+                }).ConfigureAwait(false);
 
                 _stylesheetURLs.Add(styleSheetAddedResponse.Header.StyleSheetId, styleSheetAddedResponse.Header.SourceURL);
                 _stylesheetSources.Add(styleSheetAddedResponse.Header.StyleSheetId, response.text.ToString());

--- a/lib/PuppeteerSharp/PageCoverage/JSCoverage.cs
+++ b/lib/PuppeteerSharp/PageCoverage/JSCoverage.cs
@@ -28,7 +28,7 @@ namespace PuppeteerSharp.PageCoverage
             _resetOnNavigation = false;
         }
 
-        internal async Task StartAsync(CoverageStartOptions options)
+        internal Task StartAsync(CoverageStartOptions options)
         {
             if (_enabled)
             {
@@ -42,7 +42,7 @@ namespace PuppeteerSharp.PageCoverage
 
             _client.MessageReceived += client_MessageReceived;
 
-            await Task.WhenAll(
+            return Task.WhenAll(
                 _client.SendAsync("Profiler.enable"),
                 _client.SendAsync("Profiler.startPreciseCoverage", new { callCount = false, detailed = true }),
                 _client.SendAsync("Debugger.enable"),
@@ -64,7 +64,7 @@ namespace PuppeteerSharp.PageCoverage
                _client.SendAsync("Profiler.stopPreciseCoverage"),
                _client.SendAsync("Profiler.disable"),
                _client.SendAsync("Debugger.disable")
-           );
+           ).ConfigureAwait(false);
             _client.MessageReceived -= client_MessageReceived;
 
             var coverage = new List<CoverageEntry>();
@@ -93,7 +93,7 @@ namespace PuppeteerSharp.PageCoverage
             switch (e.MessageID)
             {
                 case "Debugger.scriptParsed":
-                    await OnScriptParsed(e.MessageData.ToObject<DebuggerScriptParsedResponse>());
+                    await OnScriptParsed(e.MessageData.ToObject<DebuggerScriptParsedResponse>()).ConfigureAwait(false);
                     break;
                 case "Runtime.executionContextsCleared":
                     OnExecutionContextsCleared();
@@ -110,7 +110,7 @@ namespace PuppeteerSharp.PageCoverage
 
             try
             {
-                var response = await _client.SendAsync("Debugger.getScriptSource", new { scriptId = scriptParseResponse.ScriptId });
+                var response = await _client.SendAsync("Debugger.getScriptSource", new { scriptId = scriptParseResponse.ScriptId }).ConfigureAwait(false);
                 _scriptURLs.Add(scriptParseResponse.ScriptId, scriptParseResponse.Url);
                 _scriptSources.Add(scriptParseResponse.ScriptId, response.scriptSource.ToString());
             }

--- a/lib/PuppeteerSharp/Request.cs
+++ b/lib/PuppeteerSharp/Request.cs
@@ -173,7 +173,7 @@ namespace PuppeteerSharp
                     requestData["headers"] = overrides.Headers;
                 }
 
-                await _client.SendAsync("Network.continueInterceptedRequest", requestData);
+                await _client.SendAsync("Network.continueInterceptedRequest", requestData).ConfigureAwait(false);
             }
             catch (PuppeteerException ex)
             {
@@ -253,7 +253,7 @@ namespace PuppeteerSharp
                 {
                     {"interceptionId", InterceptionId},
                     {"rawResponse", Convert.ToBase64String(responseData)}
-                });
+                }).ConfigureAwait(false);
             }
             catch (PuppeteerException ex)
             {
@@ -290,7 +290,7 @@ namespace PuppeteerSharp
                 {
                     {"interceptionId", InterceptionId},
                     {"errorReason", errorReason}
-                });
+                }).ConfigureAwait(false);
             }
             catch (PuppeteerException ex)
             {

--- a/lib/PuppeteerSharp/Response.cs
+++ b/lib/PuppeteerSharp/Response.cs
@@ -97,14 +97,14 @@ namespace PuppeteerSharp
         {
             if (_buffer == null)
             {
-                await BodyLoadedTaskWrapper.Task;
+                await BodyLoadedTaskWrapper.Task.ConfigureAwait(false);
 
                 try
                 {
                     var response = await _client.SendAsync("Network.getResponseBody", new Dictionary<string, object>
                     {
                         {"requestId", Request.RequestId}
-                    });
+                    }).ConfigureAwait(false);
 
                     _buffer = response.body.ToString();
                 }
@@ -128,7 +128,7 @@ namespace PuppeteerSharp
         /// </summary>
         /// <seealso cref="JsonAsync{T}"/>
         /// <returns>A Task which resolves to a <see cref="JObject"/> representation of response body</returns>
-        public async Task<JObject> JsonAsync() => JObject.Parse(await TextAsync());
+        public async Task<JObject> JsonAsync() => JObject.Parse(await TextAsync().ConfigureAwait(false));
 
         /// <summary>
         /// Returns a Task which resolves to a <typeparamref name="T"/> representation of response body
@@ -136,7 +136,7 @@ namespace PuppeteerSharp
         /// <typeparam name="T">The type of the response</typeparam>
         /// <seealso cref="JsonAsync"/>
         /// <returns>A Task which resolves to a <typeparamref name="T"/> representation of response body</returns>
-        public async Task<T> JsonAsync<T>() => (await JsonAsync()).ToObject<T>();
+        public async Task<T> JsonAsync<T>() => (await JsonAsync().ConfigureAwait(false)).ToObject<T>();
 
         #endregion
     }

--- a/lib/PuppeteerSharp/Target.cs
+++ b/lib/PuppeteerSharp/Target.cs
@@ -80,20 +80,20 @@ namespace PuppeteerSharp
         /// Creates a new <see cref="Page"/>. If the target is not <c>"page"</c> returns <c>null</c>
         /// </summary>
         /// <returns>a task that returns a new <see cref="Page"/></returns>
-        public async Task<Page> PageAsync()
+        public Task<Page> PageAsync()
         {
             if (_targetInfo.Type == TargetType.Page && _pageTask == null)
             {
                 _pageTask = CreatePageAsync();
             }
 
-            return await (_pageTask ?? Task.FromResult<Page>(null));
+            return _pageTask ?? Task.FromResult<Page>(null);
         }
 
         private async Task<Page> CreatePageAsync()
         {
-            var session = await _sessionFactory();
-            return await Page.CreateAsync(session, this, Browser.IgnoreHTTPSErrors, !Browser.AppMode, Browser.ScreenshotTaskQueue);
+            var session = await _sessionFactory().ConfigureAwait(false);
+            return await Page.CreateAsync(session, this, Browser.IgnoreHTTPSErrors, !Browser.AppMode, Browser.ScreenshotTaskQueue).ConfigureAwait(false);
         }
 
         internal void TargetInfoChanged(TargetInfo targetInfo)

--- a/lib/PuppeteerSharp/WaitTask.cs
+++ b/lib/PuppeteerSharp/WaitTask.cs
@@ -158,11 +158,11 @@ async function waitForPredicatePageFunction(predicateBody, polling, timeout, ...
             JSHandle success = null;
             Exception exception = null;
 
-            var context = await _frame.GetExecutionContextAsync();
+            var context = await _frame.GetExecutionContextAsync().ConfigureAwait(false);
             try
             {
                 success = await context.EvaluateFunctionHandleAsync(WaitForPredicatePageFunction,
-                    new object[] { _predicateBody, _pollingInterval ?? (object)_polling, _timeout }.Concat(_args).ToArray());
+                    new object[] { _predicateBody, _pollingInterval ?? (object)_polling, _timeout }.Concat(_args).ToArray()).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -173,16 +173,16 @@ async function waitForPredicatePageFunction(predicateBody, polling, timeout, ...
             {
                 if (success != null)
                 {
-                    await success.DisposeAsync();
+                    await success.DisposeAsync().ConfigureAwait(false);
                 }
 
                 return;
             }
-            if (exception == null && await _frame.EvaluateFunctionAsync<bool>("s => !s", success))
+            if (exception == null && await _frame.EvaluateFunctionAsync<bool>("s => !s", success).ConfigureAwait(false))
             {
                 if (success != null)
                 {
-                    await success.DisposeAsync();
+                    await success.DisposeAsync().ConfigureAwait(false);
                 }
 
                 return;


### PR DESCRIPTION
- to prevent deadlocks, every await must be paired with .ConfigureAwait(false)
- this is especially important when puppeteer is called from context which must wait for the task synchronously, e.g. using .GetAwaiter.GetResult() or .Result property

- for more info about this topic check https://msdn.microsoft.com/en-us/magazine/jj991977.aspx?f=255&MSPPError=-2147217396
- note: it is important that all devs understand why this is needed and that future code always uses ConfigureAwait(false)