### PR TITLE
Fix SetViewportAsync instances in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ You can also change the view port before generating the screenshot
 
 
 ```cs
-await page.SetViewport(new ViewPortOptions
+await page.SetViewportAsync(new ViewPortOptions
 {
     Width = 500,
     Height = 500
@@ -63,7 +63,7 @@ await page.PdfAsync(outputFile);
 ## Inject HTML
 
 ```cs
-using(var page = await Browser.NewPageAsync())
+using(var page = await browser.NewPageAsync())
 {
     await page.SetContentAsync("<div>My Receipt</div>");
     var result = await page.GetContentAsync();
@@ -75,7 +75,7 @@ using(var page = await Browser.NewPageAsync())
 ## Evaluate Javascript
 
 ```cs
-using (var page = await Browser.NewPageAsync())
+using (var page = await browser.NewPageAsync())
 {
     var seven = await page.EvaluateFunctionAsync<int>(“4 + 3”);
     var someObject = await page.EvaluateFunctionAsync<dynamic>("(value) => ({a: value})", 5);
@@ -86,7 +86,7 @@ using (var page = await Browser.NewPageAsync())
 ## Wait For Selector
 
 ```cs
-using (var page = await Browser.NewPageAsync())
+using (var page = await browser.NewPageAsync())
 {
     await page.GoToAsync("http://www.spapage.com");
     await page.WaitForSelectorAsync("div.main-content")
@@ -96,11 +96,11 @@ using (var page = await Browser.NewPageAsync())
 
 ## Wait For Function
 ```cs
-using (var page = await Browser.NewPageAsync())
+using (var page = await browser.NewPageAsync())
 {
     await page.GoToAsync("http://www.spapage.com");
     var watchDog = page.WaitForFunctionAsync("window.innerWidth < 100");
-    await Page.SetViewport(new ViewPortOptions { Width = 50, Height = 50 });
+    await page.SetViewportAsync(new ViewPortOptions { Width = 50, Height = 50 });
     await watchDog;
 }
 ```


### PR DESCRIPTION
Also updated `browser` instances from uppercase as they are instance methods, not static methods