### PR TITLE
Explicit IConnection implementation

### DIFF
--- a/lib/PuppeteerSharp/CDPSession.cs
+++ b/lib/PuppeteerSharp/CDPSession.cs
@@ -100,13 +100,7 @@ namespace PuppeteerSharp
             return JsonConvert.DeserializeObject<T>(content);
         }
 
-        /// <summary>
-        /// Sends a message to chromium.
-        /// </summary>
-        /// <returns>The async.</returns>
-        /// <param name="method">Method to call.</param>
-        /// <param name="args">Method arguments.</param>
-        public Task<dynamic> SendAsync(string method, dynamic args = null)
+        internal Task<dynamic> SendAsync(string method, dynamic args = null)
         {
             return SendAsync(method, false, args ?? new { });
         }
@@ -250,6 +244,11 @@ namespace PuppeteerSharp
             _sessions[sessionId] = session;
             return session;
         }
+        #endregion
+        #region IConnection
+        ILoggerFactory IConnection.LoggerFactory => LoggerFactory;
+        bool IConnection.IsClosed => IsClosed;
+        Task<dynamic> IConnection.SendAsync(string method, dynamic args) => SendAsync(method, args);
         #endregion
     }
 }

--- a/lib/PuppeteerSharp/Connection.cs
+++ b/lib/PuppeteerSharp/Connection.cs
@@ -85,13 +85,7 @@ namespace PuppeteerSharp
 
         #region Public Methods
 
-        /// <summary>
-        /// Sends a message to chromium.
-        /// </summary>
-        /// <returns>The async.</returns>
-        /// <param name="method">Method to call.</param>
-        /// <param name="args">Method arguments.</param>
-        public async Task<dynamic> SendAsync(string method, dynamic args = null)
+        internal async Task<dynamic> SendAsync(string method, dynamic args = null)
         {
             var id = ++_lastId;
             var message = JsonConvert.SerializeObject(new Dictionary<string, object>
@@ -313,7 +307,12 @@ namespace PuppeteerSharp
             OnClose();
             WebSocket.Dispose();
         }
+        #endregion
 
+        #region IConnection
+        ILoggerFactory IConnection.LoggerFactory => LoggerFactory;
+        bool IConnection.IsClosed => IsClosed;
+        Task<dynamic> IConnection.SendAsync(string method, dynamic args) => SendAsync(method, args);
         #endregion
     }
 }

--- a/lib/PuppeteerSharp/IConnection.cs
+++ b/lib/PuppeteerSharp/IConnection.cs
@@ -7,7 +7,7 @@ namespace PuppeteerSharp
     /// <summary>
     /// Connection interface implemented by <see cref="Connection"/> and <see cref="CDPSession"/>
     /// </summary>
-    public interface IConnection
+    internal interface IConnection
     {
         /// <summary>
         /// Gets the logger factory.


### PR DESCRIPTION
By doing this we keep the abstraction and the SendAsync methods internal.