### PR TITLE
fix: supported thrown strings and numbers in getExceptionMessage

### DIFF
--- a/lib/PuppeteerSharp.Tests/PageTests/EvaluateTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/EvaluateTests.cs
@@ -171,6 +171,22 @@ namespace PuppeteerSharp.Tests.PageTests
         }
 
         [Fact]
+        public async Task ShouldSupportThrownStringsAsErrorMessages()
+        {
+            var exception = await Assert.ThrowsAsync<EvaluationFailedException>(
+                () => Page.EvaluateExpressionAsync("throw 'qwerty'"));
+            Assert.Contains("qwerty", exception.Message);
+        }
+
+        [Fact]
+        public async Task ShouldSupportThrownNumbersAsErrorMessages()
+        {
+            var exception = await Assert.ThrowsAsync<EvaluationFailedException>(
+                            () => Page.EvaluateExpressionAsync("throw 100500"));
+            Assert.Contains("100500", exception.Message);
+        }
+
+        [Fact]
         public async Task ShouldThrowWhenEvaluationTriggersReload()
         {
             var exception = await Assert.ThrowsAsync<MessageException>(() =>

--- a/lib/PuppeteerSharp/EvaluateExceptionInfo.cs
+++ b/lib/PuppeteerSharp/EvaluateExceptionInfo.cs
@@ -6,5 +6,8 @@ namespace PuppeteerSharp
     {
         [JsonProperty("description")]
         internal string Description { get; set; }
+
+        [JsonProperty("value")]
+        internal string Value { get; set; }
     }
 }

--- a/lib/PuppeteerSharp/ExecutionContext.cs
+++ b/lib/PuppeteerSharp/ExecutionContext.cs
@@ -233,7 +233,7 @@ namespace PuppeteerSharp
         {
             if (exceptionDetails.Exception != null)
             {
-                return exceptionDetails.Exception.Description;
+                return exceptionDetails.Exception.Description ?? exceptionDetails.Exception.Value;
             }
             var message = exceptionDetails.Text;
             if (exceptionDetails.StackTrace != null)


### PR DESCRIPTION
closes #476