### PR TITLE
added generation of DeviceDescriptors.cs

### DIFF
--- a/lib/PuppeteerSharp.DevicesFetcher/DevicePayload.cs
+++ b/lib/PuppeteerSharp.DevicesFetcher/DevicePayload.cs
@@ -1,0 +1,19 @@
+﻿using System.Collections.Generic;
+
+namespace PuppeteerSharp.DevicesFetcher
+{
+    public class DevicePayload
+    {
+        public string Type { get; set; }
+
+        public string UserAgent { get; set; }
+
+        public ViewportPayload Vertical { get; set; }
+
+        public ViewportPayload Horizontal { get; set; }
+
+        public double DeviceScaleFactor { get; set; }
+
+        public HashSet<string> Capabilities { get; set; }
+    }
+}

--- a/lib/PuppeteerSharp.DevicesFetcher/Models.cs
+++ b/lib/PuppeteerSharp.DevicesFetcher/Models.cs
@@ -1,54 +1,7 @@
-﻿using System.Collections.Generic;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace PuppeteerSharp.DevicesFetcher
 {
-    public class DevicePayload
-    {
-        public string Type { get; set; }
-
-        public string UserAgent { get; set; }
-
-        public ViewportPayload Vertical { get; set; }
-
-        public ViewportPayload Horizontal { get; set; }
-
-        public double DeviceScaleFactor { get; set; }
-
-        public HashSet<string> Capabilities { get; set; }
-    }
-
-    public class ViewportPayload
-    {
-        [JsonProperty("width")]
-        public double Width { get; set; }
-
-        [JsonProperty("height")]
-        public double Height { get; set; }
-    }
-
-    public class OutputDevice
-    {
-        public string Name { get; set; }
-        public string UserAgent { get; set; }
-        public OutputDeviceViewport Viewport { get; set; }
-
-        public class OutputDeviceViewport
-        {
-            public double Width { get; set; }
-
-            public double Height { get; set; }
-
-            public double DeviceScaleFactor { get; set; }
-
-            public bool IsMobile { get; set; }
-
-            public bool HasTouch { get; set; }
-
-            public bool IsLandscape { get; set; }
-        }
-    }
-
     public class RootObject
     {
         [JsonProperty("extensions")]
@@ -75,8 +28,7 @@ namespace PuppeteerSharp.DevicesFetcher
             [JsonProperty("user-agent")]
             public string UserAgent { get; set; }
             [JsonProperty("type")]
-            public string Type { get; set; }
-            
+            public string Type { get; set; }            
         }
 
         public class Screen

--- a/lib/PuppeteerSharp.DevicesFetcher/Models.cs
+++ b/lib/PuppeteerSharp.DevicesFetcher/Models.cs
@@ -1,0 +1,92 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace PuppeteerSharp.DevicesFetcher
+{
+    public class DevicePayload
+    {
+        public string Type { get; set; }
+
+        public string UserAgent { get; set; }
+
+        public ViewportPayload Vertical { get; set; }
+
+        public ViewportPayload Horizontal { get; set; }
+
+        public double DeviceScaleFactor { get; set; }
+
+        public HashSet<string> Capabilities { get; set; }
+    }
+
+    public class ViewportPayload
+    {
+        [JsonProperty("width")]
+        public double Width { get; set; }
+
+        [JsonProperty("height")]
+        public double Height { get; set; }
+    }
+
+    public class OutputDevice
+    {
+        public string Name { get; set; }
+        public string UserAgent { get; set; }
+        public OutputDeviceViewport Viewport { get; set; }
+
+        public class OutputDeviceViewport
+        {
+            public double Width { get; set; }
+
+            public double Height { get; set; }
+
+            public double DeviceScaleFactor { get; set; }
+
+            public bool IsMobile { get; set; }
+
+            public bool HasTouch { get; set; }
+
+            public bool IsLandscape { get; set; }
+        }
+    }
+
+    public class RootObject
+    {
+        [JsonProperty("extensions")]
+        public Extension[] Extensions { get; set; }
+
+        public class Extension
+        {
+            [JsonProperty("type")]
+            public string Type { get; set; }
+            [JsonProperty("device")]
+            public Device Device { get; set; }
+        }
+
+        public class Device
+        {
+            [JsonProperty("show-by-default")]
+            public bool ShowByDefault { get; set; }
+            [JsonProperty("title")]
+            public string Title { get; set; }
+            [JsonProperty("screen")]
+            public Screen Screen { get; set; }
+            [JsonProperty("capabilities")]
+            public string[] Capabilities { get; set; }
+            [JsonProperty("user-agent")]
+            public string UserAgent { get; set; }
+            [JsonProperty("type")]
+            public string Type { get; set; }
+            
+        }
+
+        public class Screen
+        {
+            [JsonProperty("horizontal")]
+            public ViewportPayload Horizontal { get; set; }
+            [JsonProperty("device-pixel-ratio")]
+            public double DevicePixelRatio { get; set; }
+            [JsonProperty("vertical")]
+            public ViewportPayload Vertical { get; set; }
+        }
+    }
+}

--- a/lib/PuppeteerSharp.DevicesFetcher/OutputDevice.cs
+++ b/lib/PuppeteerSharp.DevicesFetcher/OutputDevice.cs
@@ -1,0 +1,24 @@
+﻿namespace PuppeteerSharp.DevicesFetcher
+{
+    public class OutputDevice
+    {
+        public string Name { get; set; }
+        public string UserAgent { get; set; }
+        public OutputDeviceViewport Viewport { get; set; }
+
+        public class OutputDeviceViewport
+        {
+            public double Width { get; set; }
+
+            public double Height { get; set; }
+
+            public double DeviceScaleFactor { get; set; }
+
+            public bool IsMobile { get; set; }
+
+            public bool HasTouch { get; set; }
+
+            public bool IsLandscape { get; set; }
+        }
+    }
+}

--- a/lib/PuppeteerSharp.DevicesFetcher/Program.cs
+++ b/lib/PuppeteerSharp.DevicesFetcher/Program.cs
@@ -17,20 +17,18 @@ namespace PuppeteerSharp.DevicesFetcher
         static string deviceDescriptorsOutput = "../../../../PuppeteerSharp/Mobile/DeviceDescriptors.cs";
         static string deviceDescriptorNameOutput = "../../../../PuppeteerSharp/Mobile/DeviceDescriptorName.cs";
 
-        static void Main(string[] args)
+        static async Task Main(string[] args)
         {
-            var url = DEVICES_URL ?? args[0];
-
-            MainAsync(url).GetAwaiter().GetResult();
-        }
-
-        static async Task MainAsync(string url)
-        {
-            string chromeVersion = null;
-            using (var browser = await Puppeteer.LaunchAsync(new LaunchOptions
+            var url = DEVICES_URL;
+            if (args.Length > 0)
             {
-                ExecutablePath = "../../../../PuppeteerSharp.Tests/bin/Debug/netcoreapp2.0/.local-chromium/Win64-571375/chrome-win32/chrome.exe"
-            }))
+                url = args[0];
+            }
+
+            string chromeVersion = null;
+            var fetcher = new BrowserFetcher();
+            await fetcher.DownloadAsync(BrowserFetcher.DefaultRevision);
+            using (var browser = await Puppeteer.LaunchAsync(new LaunchOptions()))
             {
                 chromeVersion = (await browser.GetVersionAsync()).Split('/').Last();
             }
@@ -106,11 +104,11 @@ namespace PuppeteerSharp.Mobile
             var end = @"
         };
             
-        /// <summary>	
-        /// Get the specified device description.	
-        /// </summary>	
-        /// <returns>The device descriptor.</returns>	
-        /// <param name=""name"">Device Name.</param>	
+        /// <summary>
+        /// Get the specified device description.
+        /// </summary>
+        /// <returns>The device descriptor.</returns>
+        /// <param name=""name"">Device Name.</param>
         public static DeviceDescriptor Get(DeviceDescriptorName name) => Devices[name];
     }
 }";

--- a/lib/PuppeteerSharp.DevicesFetcher/Program.cs
+++ b/lib/PuppeteerSharp.DevicesFetcher/Program.cs
@@ -1,0 +1,267 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace PuppeteerSharp.DevicesFetcher
+{
+    class Program
+    {
+        const string DEVICES_URL = "https://raw.githubusercontent.com/ChromeDevTools/devtools-frontend/master/front_end/emulated_devices/module.json";
+        const string HELP_MESSAGE = @"Usage: dotnet run [-u <from>] <outputPath>
+  -u, --url    The URL to load devices descriptor from. If not set,
+               devices will be fetched from the tip-of-tree of DevTools
+               frontend.
+
+  -h, --help   Show this help message
+
+Fetch Chrome DevTools front-end emulation devices from given URL, convert them to puppeteer
+devices and save to the <outputPath>.
+";
+        const string TEMPLATE = @"/**
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the ""License"");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an ""AS IS"" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module.exports = {0};
+for (let device of module.exports)
+  module.exports[device.name] = device;
+";
+        static string outputPath;
+
+        static void Main(string[] args)
+        {
+            var url = DEVICES_URL ?? args[0];
+            outputPath = "./DeviceDescriptors.js" ?? args[1];
+
+            MainAsync(url).GetAwaiter().GetResult();
+        }
+
+        static async Task MainAsync(string url)
+        {
+            string chromeVersion;
+            using (var browser = await PuppeteerSharp.Puppeteer.LaunchAsync(new LaunchOptions
+            {
+                ExecutablePath = @"../PuppeteerSharp.Tests/bin/Debug/netcoreapp2.0/.local-chromium/Win64-571375/chrome-win32/chrome.exe"
+            }))
+            {
+                chromeVersion = (await browser.GetVersionAsync()).Split('/').Last();
+            }
+            Console.WriteLine($"GET {url}");
+            var text = await HttpGET(url);
+            RootObject json = null;
+            try
+            {
+                json = JsonConvert.DeserializeObject<RootObject>(text);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"FAILED: error parsing response - {ex.Message}");
+            }
+            var devicePayloads = json.Extensions
+                .Where(extension => extension.Type == "emulated-device")
+                .Select(extension => extension.Device)
+                .ToArray();
+            var devices = new List<OutputDevice>();
+            foreach (var payload in devicePayloads)
+            {
+                string[] names;
+                if (payload.Title == "iPhone 6/7/8")
+                {
+                    names = new[] { "iPhone 6", "iPhone 7", "iPhone 8" };
+                }
+                else if (payload.Title == "iPhone 6/7/8 Plus")
+                {
+                    names = new[] { "iPhone 6 Plus", "iPhone 7 Plus", "iPhone 8 Plus" };
+                }
+                else if (payload.Title == "iPhone 5/SE")
+                {
+                    names = new[] { "iPhone 5", "iPhone SE" };
+                }
+                else
+                {
+                    names = new[] { payload.Title };
+                }
+                foreach (var name in names)
+                {
+                    var device = CreateDevice(chromeVersion, name, payload, false);
+                    var landscape = CreateDevice(chromeVersion, name, payload, true);
+                    devices.Add(device);
+                    if (landscape.viewport.width != device.viewport.width || landscape.viewport.height != device.viewport.height)
+                        devices.Add(landscape);
+                }
+            }
+            devices.RemoveAll(device => !device.viewport.isMobile);
+            devices.Sort((a, b) => a.name.CompareTo(b.name));
+            File.WriteAllText(outputPath, string.Format(TEMPLATE, JsonConvert.SerializeObject(devices, Formatting.Indented))
+                .Replace('/', '\\')
+                .Replace('"', '\''));
+        }
+
+        static OutputDevice CreateDevice(string chromeVersion, string deviceName, RootObject.Device descriptor, bool landscape)
+        {
+            var devicePayload = LoadFromJSONV1(descriptor);
+            var viewportPayload = landscape ? devicePayload.horizontal : devicePayload.vertical;
+            return new OutputDevice
+            {
+                name = deviceName + (landscape ? " landscape" : string.Empty),
+                userAgent = devicePayload.userAgent.Replace("%s", chromeVersion),
+                viewport = new OutputDevice.OutputDeviceViewport
+                {
+                    width = viewportPayload.width,
+                    height = viewportPayload.height,
+                    deviceScaleFactor = devicePayload.deviceScaleFactor,
+                    isMobile = devicePayload.capabilities.Contains("mobile"),
+                    hasTouch = devicePayload.capabilities.Contains("touch"),
+                    isLandscape = landscape
+                }
+            };
+        }
+
+        static DevicePayload LoadFromJSONV1(RootObject.Device json) => new DevicePayload
+        {
+            type = json.type,
+            userAgent = json.UserAgent,
+            capabilities = json.Capabilities.ToHashSet(),
+            deviceScaleFactor = json.Screen.DevicePixelRatio,
+            horizontal = new DevicePayload.ViewportPayload
+            {
+                height = json.Screen.horizontal.height,
+                width = json.Screen.horizontal.width
+            },
+            vertical = new DevicePayload.ViewportPayload
+            {
+                height = json.Screen.vertical.height,
+                width = json.Screen.vertical.width
+            }
+        };
+
+        static Task<string> HttpGET(string url) => new HttpClient().GetStringAsync(url);
+    }
+
+    public class DevicePayload
+    {
+        public string type { get; set; }
+        public string userAgent { get; set; }
+        public ViewportPayload vertical { get; set; }
+        public ViewportPayload horizontal { get; set; }
+
+        public double deviceScaleFactor { get; set; }
+        public HashSet<string> capabilities { get; set; }
+
+        public class ViewportPayload
+        {
+            public double width { get; set; }
+            public double height { get; set; }
+        }
+    }
+
+    public class OutputDevice
+    {
+        public string name { get; set; }
+        public string userAgent { get; set; }
+        public OutputDeviceViewport viewport { get; set; }
+
+        public class OutputDeviceViewport
+        {
+            public double width { get; set; }
+            public double height { get; set; }
+            public double deviceScaleFactor { get; set; }
+            public bool isMobile { get; set; }
+            public bool hasTouch { get; set; }
+            public bool isLandscape { get; set; }
+        }
+    }
+
+    public class RootObject
+    {
+        [JsonProperty("extensions")]
+        public Extension[] Extensions { get; set; }
+
+        public class Extension
+        {
+            [JsonProperty("type")]
+            public string Type { get; set; }
+            [JsonProperty("device")]
+            public Device Device { get; set; }
+        }
+
+        public class Device
+        {
+            [JsonProperty("show-by-default")]
+            public bool ShowByDefault { get; set; }
+            [JsonProperty("title")]
+            public string Title { get; set; }
+            [JsonProperty("screen")]
+            public Screen Screen { get; set; }
+            [JsonProperty("capabilities")]
+            public string[] Capabilities { get; set; }
+            [JsonProperty("user-agent")]
+            public string UserAgent { get; set; }
+            [JsonProperty("type")]
+            public string type { get; set; }
+            [JsonProperty("modes")]
+            public Mode[] Modes { get; set; }
+        }
+
+        public class Screen
+        {
+            public Horizontal horizontal { get; set; }
+            [JsonProperty("device-pixel-ratio")]
+            public double DevicePixelRatio { get; set; }
+            public Vertical vertical { get; set; }
+        }
+
+        public class Horizontal
+        {
+            public int width { get; set; }
+            public int height { get; set; }
+            public Outline outline { get; set; }
+        }
+
+        public class Outline
+        {
+            public string image { get; set; }
+            public Insets insets { get; set; }
+        }
+
+        public class Insets
+        {
+            public int left { get; set; }
+            public int top { get; set; }
+            public int right { get; set; }
+            public int bottom { get; set; }
+        }
+
+        public class Vertical
+        {
+            public int width { get; set; }
+            public int height { get; set; }
+            public Outline outline { get; set; }
+        }
+
+        public class Mode
+        {
+            public string title { get; set; }
+            public string orientation { get; set; }
+            public Insets insets { get; set; }
+            public string image { get; set; }
+        }
+    }
+
+}

--- a/lib/PuppeteerSharp.DevicesFetcher/Program.cs
+++ b/lib/PuppeteerSharp.DevicesFetcher/Program.cs
@@ -131,8 +131,7 @@ namespace PuppeteerSharp.Mobile
     /// Device descriptor name.
     /// </summary>
     public enum DeviceDescriptorName
-    {
-";
+    {";
             var end = @"
     }
 }";

--- a/lib/PuppeteerSharp.DevicesFetcher/Program.cs
+++ b/lib/PuppeteerSharp.DevicesFetcher/Program.cs
@@ -105,6 +105,13 @@ namespace PuppeteerSharp.Mobile
 ";
             var end = @"
         };
+            
+        /// <summary>	
+        /// Get the specified device description.	
+        /// </summary>	
+        /// <returns>The device descriptor.</returns>	
+        /// <param name=""name"">Device Name.</param>	
+        public static DeviceDescriptor Get(DeviceDescriptorName name) => Devices[name];
     }
 }";
 

--- a/lib/PuppeteerSharp.DevicesFetcher/Program.cs
+++ b/lib/PuppeteerSharp.DevicesFetcher/Program.cs
@@ -182,7 +182,6 @@ namespace PuppeteerSharp.Mobile
             return output.ToString();
         }
 
-
         static OutputDevice CreateDevice(string chromeVersion, string deviceName, RootObject.Device descriptor, bool landscape)
         {
             var devicePayload = LoadFromJSONV1(descriptor);

--- a/lib/PuppeteerSharp.DevicesFetcher/PuppeteerSharp.DevicesFetcher.csproj
+++ b/lib/PuppeteerSharp.DevicesFetcher/PuppeteerSharp.DevicesFetcher.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.0</TargetFramework>
+      <LangVersion>7.2</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/lib/PuppeteerSharp.DevicesFetcher/PuppeteerSharp.DevicesFetcher.csproj
+++ b/lib/PuppeteerSharp.DevicesFetcher/PuppeteerSharp.DevicesFetcher.csproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\PuppeteerSharp\PuppeteerSharp.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/lib/PuppeteerSharp.DevicesFetcher/ViewportPayload.cs
+++ b/lib/PuppeteerSharp.DevicesFetcher/ViewportPayload.cs
@@ -1,0 +1,13 @@
+﻿using Newtonsoft.Json;
+
+namespace PuppeteerSharp.DevicesFetcher
+{
+    public class ViewportPayload
+    {
+        [JsonProperty("width")]
+        public double Width { get; set; }
+
+        [JsonProperty("height")]
+        public double Height { get; set; }
+    }
+}

--- a/lib/PuppeteerSharp.sln
+++ b/lib/PuppeteerSharp.sln
@@ -1,4 +1,4 @@
-Microsoft Visual Studio Solution File, Format Version 12.00
+﻿Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.27703.2035
 MinimumVisualStudioVersion = 10.0.40219.1
@@ -11,6 +11,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PuppeteerSharp.Tests.DumpIO", "PuppeteerSharp.Tests.DumpIO\PuppeteerSharp.Tests.DumpIO.csproj", "{B1892212-CEE3-4DC3-ADB8-04A2D9A081A0}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PuppeteerSharp.Tests.CloseMe", "PuppeteerSharp.Tests.CloseMe\PuppeteerSharp.Tests.CloseMe.csproj", "{B1B0358F-88A2-4038-9974-7850D906C76B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PuppeteerSharp.DevicesFetcher", "PuppeteerSharp.DevicesFetcher\PuppeteerSharp.DevicesFetcher.csproj", "{A500694A-3649-4474-BC71-C835FA19B865}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -38,6 +40,10 @@ Global
 		{B1B0358F-88A2-4038-9974-7850D906C76B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B1B0358F-88A2-4038-9974-7850D906C76B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B1B0358F-88A2-4038-9974-7850D906C76B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A500694A-3649-4474-BC71-C835FA19B865}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A500694A-3649-4474-BC71-C835FA19B865}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A500694A-3649-4474-BC71-C835FA19B865}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A500694A-3649-4474-BC71-C835FA19B865}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/lib/PuppeteerSharp/Mobile/DeviceDescriptorName.cs
+++ b/lib/PuppeteerSharp/Mobile/DeviceDescriptorName.cs
@@ -1,220 +1,261 @@
-﻿namespace PuppeteerSharp.Mobile
+namespace PuppeteerSharp.Mobile
 {
     /// <summary>
     /// Device descriptor name.
     /// </summary>
     public enum DeviceDescriptorName
     {
+
         /// <summary>
-        /// Blackberry PlayBook.
+        /// Blackberry PlayBook
         /// </summary>
         BlackberryPlayBook,
         /// <summary>
-        /// blackberry PlayBook landscape.
+        /// Blackberry PlayBook landscape
         /// </summary>
         BlackberryPlayBookLandscape,
         /// <summary>
-        /// Blackberry z30.
+        /// BlackBerry Z30
         /// </summary>
         BlackBerryZ30,
         /// <summary>
-        /// Blackberry z30 landscape.
+        /// BlackBerry Z30 landscape
         /// </summary>
         BlackBerryZ30Landscape,
         /// <summary>
-        /// Galaxy note 3.
+        /// Galaxy Note 3
         /// </summary>
         GalaxyNote3,
         /// <summary>
-        /// Galaxy note 3 landscape.
+        /// Galaxy Note 3 landscape
         /// </summary>
         GalaxyNote3Landscape,
         /// <summary>
-        /// Galaxy note II.
+        /// Galaxy Note II
         /// </summary>
         GalaxyNoteII,
         /// <summary>
-        /// Galaxy note II Landscape.
+        /// Galaxy Note II landscape
         /// </summary>
         GalaxyNoteIILandscape,
         /// <summary>
-        /// Galaxy S III.
+        /// Galaxy S III
         /// </summary>
         GalaxySIII,
         /// <summary>
-        /// Galaxy S III Landscape.
+        /// Galaxy S III landscape
         /// </summary>
         GalaxySIIILandscape,
         /// <summary>
-        /// Galaxy S5.
+        /// Galaxy S5
         /// </summary>
         GalaxyS5,
         /// <summary>
-        /// Galaxy S5 landscape.
+        /// Galaxy S5 landscape
         /// </summary>
         GalaxyS5Landscape,
         /// <summary>
-        /// iPad.
+        /// iPad
         /// </summary>
         IPad,
         /// <summary>
-        /// iPad landscape.
+        /// iPad landscape
         /// </summary>
         IPadLandscape,
         /// <summary>
-        /// iPad mini.
+        /// iPad Mini
         /// </summary>
         IPadMini,
         /// <summary>
-        /// iPad mini landscape.
+        /// iPad Mini landscape
         /// </summary>
         IPadMiniLandscape,
         /// <summary>
-        /// iPad pro.
+        /// iPad Pro
         /// </summary>
         IPadPro,
         /// <summary>
-        /// iPad pro landscape.
+        /// iPad Pro landscape
         /// </summary>
         IPadProLandscape,
         /// <summary>
-        /// iPhone 4.
+        /// iPhone 4
         /// </summary>
         IPhone4,
         /// <summary>
-        /// iPhone 4 landscape.
+        /// iPhone 4 landscape
         /// </summary>
         IPhone4Landscape,
         /// <summary>
-        /// iPhone 5.
+        /// iPhone 5
         /// </summary>
         IPhone5,
         /// <summary>
-        /// iPhone 5 landscape.
+        /// iPhone 5 landscape
         /// </summary>
         IPhone5Landscape,
         /// <summary>
-        /// iPhone 6.
+        /// iPhone 6
         /// </summary>
         IPhone6,
         /// <summary>
-        /// iPhone 6 landscape.
+        /// iPhone 6 landscape
         /// </summary>
         IPhone6Landscape,
         /// <summary>
-        /// iPhone 6 plus.
+        /// iPhone 6 Plus
         /// </summary>
         IPhone6Plus,
         /// <summary>
-        /// iPhone 6 plus landscape.
-        /// </summary>
-        IPhoneX,
-        /// <summary>
-        /// iPhone 6 plus landscape.
+        /// iPhone 6 Plus landscape
         /// </summary>
         IPhone6PlusLandscape,
         /// <summary>
-        /// iPhone X Landscape.
+        /// iPhone 7
+        /// </summary>
+        IPhone7,
+        /// <summary>
+        /// iPhone 7 landscape
+        /// </summary>
+        IPhone7Landscape,
+        /// <summary>
+        /// iPhone 7 Plus
+        /// </summary>
+        IPhone7Plus,
+        /// <summary>
+        /// iPhone 7 Plus landscape
+        /// </summary>
+        IPhone7PlusLandscape,
+        /// <summary>
+        /// iPhone 8
+        /// </summary>
+        IPhone8,
+        /// <summary>
+        /// iPhone 8 landscape
+        /// </summary>
+        IPhone8Landscape,
+        /// <summary>
+        /// iPhone 8 Plus
+        /// </summary>
+        IPhone8Plus,
+        /// <summary>
+        /// iPhone 8 Plus landscape
+        /// </summary>
+        IPhone8PlusLandscape,
+        /// <summary>
+        /// iPhone SE
+        /// </summary>
+        IPhoneSE,
+        /// <summary>
+        /// iPhone SE landscape
+        /// </summary>
+        IPhoneSELandscape,
+        /// <summary>
+        /// iPhone X
+        /// </summary>
+        IPhoneX,
+        /// <summary>
+        /// iPhone X landscape
         /// </summary>
         IPhoneXLandscape,
         /// <summary>
-        /// Kindle fire hdx.
+        /// Kindle Fire HDX
         /// </summary>
         KindleFireHDX,
         /// <summary>
-        /// Kindle fire HDXL andscape.
+        /// Kindle Fire HDX landscape
         /// </summary>
         KindleFireHDXLandscape,
         /// <summary>
-        /// LG Optimus L70.
+        /// LG Optimus L70
         /// </summary>
         LGOptimusL70,
         /// <summary>
-        /// LG Optimus L70 landscape.
+        /// LG Optimus L70 landscape
         /// </summary>
         LGOptimusL70Landscape,
         /// <summary>
-        /// Microsoft Lumia 550.
+        /// Microsoft Lumia 550
         /// </summary>
         MicrosoftLumia550,
         /// <summary>
-        /// Microsoft Lumia 950.
+        /// Microsoft Lumia 950
         /// </summary>
         MicrosoftLumia950,
         /// <summary>
-        /// Microsoft Lumia 950 landscape.
+        /// Microsoft Lumia 950 landscape
         /// </summary>
         MicrosoftLumia950Landscape,
         /// <summary>
-        /// Nexus 10.
+        /// Nexus 10
         /// </summary>
         Nexus10,
         /// <summary>
-        /// Nexus 10 landscape.
+        /// Nexus 10 landscape
         /// </summary>
         Nexus10Landscape,
         /// <summary>
-        /// Nexus 4.
+        /// Nexus 4
         /// </summary>
         Nexus4,
         /// <summary>
-        /// Nexus 4 landscape.
+        /// Nexus 4 landscape
         /// </summary>
         Nexus4Landscape,
         /// <summary>
-        /// Nexus 5.
+        /// Nexus 5
         /// </summary>
         Nexus5,
         /// <summary>
-        /// Nexus 5 landscape.
+        /// Nexus 5 landscape
         /// </summary>
         Nexus5Landscape,
         /// <summary>
-        /// Nexus 5X.
+        /// Nexus 5X
         /// </summary>
         Nexus5X,
         /// <summary>
-        /// Nexus 5X Landscape.
+        /// Nexus 5X landscape
         /// </summary>
         Nexus5XLandscape,
         /// <summary>
-        /// Nexus6.
+        /// Nexus 6
         /// </summary>
         Nexus6,
         /// <summary>
-        /// Nexus 6 landscape.
+        /// Nexus 6 landscape
         /// </summary>
         Nexus6Landscape,
         /// <summary>
-        /// Nexus 6P.
+        /// Nexus 6P
         /// </summary>
         Nexus6P,
         /// <summary>
-        /// Nexus 6P Landscape.
+        /// Nexus 6P landscape
         /// </summary>
         Nexus6PLandscape,
         /// <summary>
-        /// Nexus7.
+        /// Nexus 7
         /// </summary>
         Nexus7,
         /// <summary>
-        /// Nexus 7 landscape.
+        /// Nexus 7 landscape
         /// </summary>
         Nexus7Landscape,
         /// <summary>
-        /// Nokia Lumia 520.
+        /// Nokia Lumia 520
         /// </summary>
         NokiaLumia520,
         /// <summary>
-        /// Nokia Lumia 520 landscape.
+        /// Nokia Lumia 520 landscape
         /// </summary>
         NokiaLumia520Landscape,
         /// <summary>
-        /// Nokia N9.
+        /// Nokia N9
         /// </summary>
         NokiaN9,
         /// <summary>
-        /// Nokia N9 landscape.
+        /// Nokia N9 landscape
         /// </summary>
         NokiaN9Landscape,
         /// <summary>

--- a/lib/PuppeteerSharp/Mobile/DeviceDescriptorName.cs
+++ b/lib/PuppeteerSharp/Mobile/DeviceDescriptorName.cs
@@ -5,7 +5,6 @@ namespace PuppeteerSharp.Mobile
     /// </summary>
     public enum DeviceDescriptorName
     {
-
         /// <summary>
         /// Blackberry PlayBook
         /// </summary>

--- a/lib/PuppeteerSharp/Mobile/DeviceDescriptors.cs
+++ b/lib/PuppeteerSharp/Mobile/DeviceDescriptors.cs
@@ -949,11 +949,11 @@ namespace PuppeteerSharp.Mobile
             }
         };
             
-        /// <summary>	
-        /// Get the specified device description.	
-        /// </summary>	
-        /// <returns>The device descriptor.</returns>	
-        /// <param name="name">Device Name.</param>	
+        /// <summary>
+        /// Get the specified device description.
+        /// </summary>
+        /// <returns>The device descriptor.</returns>
+        /// <param name="name">Device Name.</param>
         public static DeviceDescriptor Get(DeviceDescriptorName name) => Devices[name];
     }
 }

--- a/lib/PuppeteerSharp/Mobile/DeviceDescriptors.cs
+++ b/lib/PuppeteerSharp/Mobile/DeviceDescriptors.cs
@@ -1,11 +1,11 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace PuppeteerSharp.Mobile
 {
     /// <summary>
     /// Device descriptors.
     /// </summary>
-    public static class DeviceDescriptors
+    public class DeviceDescriptors
     {
         private static readonly Dictionary<DeviceDescriptorName, DeviceDescriptor> Devices = new Dictionary<DeviceDescriptorName, DeviceDescriptor>
         {
@@ -21,6 +21,20 @@ namespace PuppeteerSharp.Mobile
                     IsMobile = true,
                     HasTouch = true,
                     IsLandscape = false
+                }
+            },
+            [DeviceDescriptorName.BlackberryPlayBookLandscape] = new DeviceDescriptor
+            {
+                Name = "Blackberry PlayBook landscape",
+                UserAgent = "Mozilla/5.0 (PlayBook; U; RIM Tablet OS 2.1.0; en-US) AppleWebKit/536.2+ (KHTML like Gecko) Version/7.2.1.0 Safari/536.2+",
+                ViewPort = new ViewPortOptions
+                {
+                    Width = 1024,
+                    Height = 600,
+                    DeviceScaleFactor = 1,
+                    IsMobile = true,
+                    HasTouch = true,
+                    IsLandscape = true
                 }
             },
             [DeviceDescriptorName.BlackBerryZ30] = new DeviceDescriptor
@@ -138,7 +152,7 @@ namespace PuppeteerSharp.Mobile
             [DeviceDescriptorName.GalaxyS5] = new DeviceDescriptor
             {
                 Name = "Galaxy S5",
-                UserAgent = "Mozilla/5.0 (Linux; Android 5.0; SM-G900P Build/LRX21T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/%s Mobile Safari/537.36",
+                UserAgent = "Mozilla/5.0 (Linux; Android 5.0; SM-G900P Build/LRX21T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3477.0 Mobile Safari/537.36",
                 ViewPort = new ViewPortOptions
                 {
                     Width = 360,
@@ -152,7 +166,7 @@ namespace PuppeteerSharp.Mobile
             [DeviceDescriptorName.GalaxyS5Landscape] = new DeviceDescriptor
             {
                 Name = "Galaxy S5 landscape",
-                UserAgent = "Mozilla/5.0 (Linux; Android 5.0; SM-G900P Build/LRX21T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/%s Mobile Safari/537.36",
+                UserAgent = "Mozilla/5.0 (Linux; Android 5.0; SM-G900P Build/LRX21T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3477.0 Mobile Safari/537.36",
                 ViewPort = new ViewPortOptions
                 {
                     Width = 640,
@@ -166,7 +180,7 @@ namespace PuppeteerSharp.Mobile
             [DeviceDescriptorName.IPad] = new DeviceDescriptor
             {
                 Name = "iPad",
-                UserAgent = "Mozilla/5.0 (iPad; CPU OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1",
+                UserAgent = "Mozilla/5.0 (iPad; CPU OS 11_0 like Mac OS X) AppleWebKit/604.1.34 (KHTML, like Gecko) Version/11.0 Mobile/15A5341f Safari/604.1",
                 ViewPort = new ViewPortOptions
                 {
                     Width = 768,
@@ -180,7 +194,7 @@ namespace PuppeteerSharp.Mobile
             [DeviceDescriptorName.IPadLandscape] = new DeviceDescriptor
             {
                 Name = "iPad landscape",
-                UserAgent = "Mozilla/5.0 (iPad; CPU OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1",
+                UserAgent = "Mozilla/5.0 (iPad; CPU OS 11_0 like Mac OS X) AppleWebKit/604.1.34 (KHTML, like Gecko) Version/11.0 Mobile/15A5341f Safari/604.1",
                 ViewPort = new ViewPortOptions
                 {
                     Width = 1024,
@@ -194,7 +208,7 @@ namespace PuppeteerSharp.Mobile
             [DeviceDescriptorName.IPadMini] = new DeviceDescriptor
             {
                 Name = "iPad Mini",
-                UserAgent = "Mozilla/5.0 (iPad; CPU OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1",
+                UserAgent = "Mozilla/5.0 (iPad; CPU OS 11_0 like Mac OS X) AppleWebKit/604.1.34 (KHTML, like Gecko) Version/11.0 Mobile/15A5341f Safari/604.1",
                 ViewPort = new ViewPortOptions
                 {
                     Width = 768,
@@ -208,7 +222,7 @@ namespace PuppeteerSharp.Mobile
             [DeviceDescriptorName.IPadMiniLandscape] = new DeviceDescriptor
             {
                 Name = "iPad Mini landscape",
-                UserAgent = "Mozilla/5.0 (iPad; CPU OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1",
+                UserAgent = "Mozilla/5.0 (iPad; CPU OS 11_0 like Mac OS X) AppleWebKit/604.1.34 (KHTML, like Gecko) Version/11.0 Mobile/15A5341f Safari/604.1",
                 ViewPort = new ViewPortOptions
                 {
                     Width = 1024,
@@ -222,7 +236,7 @@ namespace PuppeteerSharp.Mobile
             [DeviceDescriptorName.IPadPro] = new DeviceDescriptor
             {
                 Name = "iPad Pro",
-                UserAgent = "Mozilla/5.0 (iPad; CPU OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1",
+                UserAgent = "Mozilla/5.0 (iPad; CPU OS 11_0 like Mac OS X) AppleWebKit/604.1.34 (KHTML, like Gecko) Version/11.0 Mobile/15A5341f Safari/604.1",
                 ViewPort = new ViewPortOptions
                 {
                     Width = 1024,
@@ -236,7 +250,7 @@ namespace PuppeteerSharp.Mobile
             [DeviceDescriptorName.IPadProLandscape] = new DeviceDescriptor
             {
                 Name = "iPad Pro landscape",
-                UserAgent = "Mozilla/5.0 (iPad; CPU OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1",
+                UserAgent = "Mozilla/5.0 (iPad; CPU OS 11_0 like Mac OS X) AppleWebKit/604.1.34 (KHTML, like Gecko) Version/11.0 Mobile/15A5341f Safari/604.1",
                 ViewPort = new ViewPortOptions
                 {
                     Width = 1366,
@@ -250,7 +264,7 @@ namespace PuppeteerSharp.Mobile
             [DeviceDescriptorName.IPhone4] = new DeviceDescriptor
             {
                 Name = "iPhone 4",
-                UserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1",
+                UserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 7_1_2 like Mac OS X) AppleWebKit/537.51.2 (KHTML, like Gecko) Version/7.0 Mobile/11D257 Safari/9537.53",
                 ViewPort = new ViewPortOptions
                 {
                     Width = 320,
@@ -264,7 +278,7 @@ namespace PuppeteerSharp.Mobile
             [DeviceDescriptorName.IPhone4Landscape] = new DeviceDescriptor
             {
                 Name = "iPhone 4 landscape",
-                UserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1",
+                UserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 7_1_2 like Mac OS X) AppleWebKit/537.51.2 (KHTML, like Gecko) Version/7.0 Mobile/11D257 Safari/9537.53",
                 ViewPort = new ViewPortOptions
                 {
                     Width = 480,
@@ -278,7 +292,7 @@ namespace PuppeteerSharp.Mobile
             [DeviceDescriptorName.IPhone5] = new DeviceDescriptor
             {
                 Name = "iPhone 5",
-                UserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1",
+                UserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_1 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/10.0 Mobile/14E304 Safari/602.1",
                 ViewPort = new ViewPortOptions
                 {
                     Width = 320,
@@ -292,7 +306,7 @@ namespace PuppeteerSharp.Mobile
             [DeviceDescriptorName.IPhone5Landscape] = new DeviceDescriptor
             {
                 Name = "iPhone 5 landscape",
-                UserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1",
+                UserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_1 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/10.0 Mobile/14E304 Safari/602.1",
                 ViewPort = new ViewPortOptions
                 {
                     Width = 568,
@@ -306,7 +320,7 @@ namespace PuppeteerSharp.Mobile
             [DeviceDescriptorName.IPhone6] = new DeviceDescriptor
             {
                 Name = "iPhone 6",
-                UserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1",
+                UserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1",
                 ViewPort = new ViewPortOptions
                 {
                     Width = 375,
@@ -320,7 +334,7 @@ namespace PuppeteerSharp.Mobile
             [DeviceDescriptorName.IPhone6Landscape] = new DeviceDescriptor
             {
                 Name = "iPhone 6 landscape",
-                UserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1",
+                UserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1",
                 ViewPort = new ViewPortOptions
                 {
                     Width = 667,
@@ -334,7 +348,7 @@ namespace PuppeteerSharp.Mobile
             [DeviceDescriptorName.IPhone6Plus] = new DeviceDescriptor
             {
                 Name = "iPhone 6 Plus",
-                UserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1",
+                UserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1",
                 ViewPort = new ViewPortOptions
                 {
                     Width = 414,
@@ -348,12 +362,152 @@ namespace PuppeteerSharp.Mobile
             [DeviceDescriptorName.IPhone6PlusLandscape] = new DeviceDescriptor
             {
                 Name = "iPhone 6 Plus landscape",
-                UserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1",
+                UserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1",
                 ViewPort = new ViewPortOptions
                 {
                     Width = 736,
                     Height = 414,
                     DeviceScaleFactor = 3,
+                    IsMobile = true,
+                    HasTouch = true,
+                    IsLandscape = true
+                }
+            },
+            [DeviceDescriptorName.IPhone7] = new DeviceDescriptor
+            {
+                Name = "iPhone 7",
+                UserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1",
+                ViewPort = new ViewPortOptions
+                {
+                    Width = 375,
+                    Height = 667,
+                    DeviceScaleFactor = 2,
+                    IsMobile = true,
+                    HasTouch = true,
+                    IsLandscape = false
+                }
+            },
+            [DeviceDescriptorName.IPhone7Landscape] = new DeviceDescriptor
+            {
+                Name = "iPhone 7 landscape",
+                UserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1",
+                ViewPort = new ViewPortOptions
+                {
+                    Width = 667,
+                    Height = 375,
+                    DeviceScaleFactor = 2,
+                    IsMobile = true,
+                    HasTouch = true,
+                    IsLandscape = true
+                }
+            },
+            [DeviceDescriptorName.IPhone7Plus] = new DeviceDescriptor
+            {
+                Name = "iPhone 7 Plus",
+                UserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1",
+                ViewPort = new ViewPortOptions
+                {
+                    Width = 414,
+                    Height = 736,
+                    DeviceScaleFactor = 3,
+                    IsMobile = true,
+                    HasTouch = true,
+                    IsLandscape = false
+                }
+            },
+            [DeviceDescriptorName.IPhone7PlusLandscape] = new DeviceDescriptor
+            {
+                Name = "iPhone 7 Plus landscape",
+                UserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1",
+                ViewPort = new ViewPortOptions
+                {
+                    Width = 736,
+                    Height = 414,
+                    DeviceScaleFactor = 3,
+                    IsMobile = true,
+                    HasTouch = true,
+                    IsLandscape = true
+                }
+            },
+            [DeviceDescriptorName.IPhone8] = new DeviceDescriptor
+            {
+                Name = "iPhone 8",
+                UserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1",
+                ViewPort = new ViewPortOptions
+                {
+                    Width = 375,
+                    Height = 667,
+                    DeviceScaleFactor = 2,
+                    IsMobile = true,
+                    HasTouch = true,
+                    IsLandscape = false
+                }
+            },
+            [DeviceDescriptorName.IPhone8Landscape] = new DeviceDescriptor
+            {
+                Name = "iPhone 8 landscape",
+                UserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1",
+                ViewPort = new ViewPortOptions
+                {
+                    Width = 667,
+                    Height = 375,
+                    DeviceScaleFactor = 2,
+                    IsMobile = true,
+                    HasTouch = true,
+                    IsLandscape = true
+                }
+            },
+            [DeviceDescriptorName.IPhone8Plus] = new DeviceDescriptor
+            {
+                Name = "iPhone 8 Plus",
+                UserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1",
+                ViewPort = new ViewPortOptions
+                {
+                    Width = 414,
+                    Height = 736,
+                    DeviceScaleFactor = 3,
+                    IsMobile = true,
+                    HasTouch = true,
+                    IsLandscape = false
+                }
+            },
+            [DeviceDescriptorName.IPhone8PlusLandscape] = new DeviceDescriptor
+            {
+                Name = "iPhone 8 Plus landscape",
+                UserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1",
+                ViewPort = new ViewPortOptions
+                {
+                    Width = 736,
+                    Height = 414,
+                    DeviceScaleFactor = 3,
+                    IsMobile = true,
+                    HasTouch = true,
+                    IsLandscape = true
+                }
+            },
+            [DeviceDescriptorName.IPhoneSE] = new DeviceDescriptor
+            {
+                Name = "iPhone SE",
+                UserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_1 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/10.0 Mobile/14E304 Safari/602.1",
+                ViewPort = new ViewPortOptions
+                {
+                    Width = 320,
+                    Height = 568,
+                    DeviceScaleFactor = 2,
+                    IsMobile = true,
+                    HasTouch = true,
+                    IsLandscape = false
+                }
+            },
+            [DeviceDescriptorName.IPhoneSELandscape] = new DeviceDescriptor
+            {
+                Name = "iPhone SE landscape",
+                UserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_1 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/10.0 Mobile/14E304 Safari/602.1",
+                ViewPort = new ViewPortOptions
+                {
+                    Width = 568,
+                    Height = 320,
+                    DeviceScaleFactor = 2,
                     IsMobile = true,
                     HasTouch = true,
                     IsLandscape = true
@@ -418,7 +572,7 @@ namespace PuppeteerSharp.Mobile
             [DeviceDescriptorName.LGOptimusL70] = new DeviceDescriptor
             {
                 Name = "LG Optimus L70",
-                UserAgent = "Mozilla/5.0 (Linux; U; Android 4.4.2; en-us; LGMS323 Build/KOT49I.MS32310c) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/%s Mobile Safari/537.36",
+                UserAgent = "Mozilla/5.0 (Linux; U; Android 4.4.2; en-us; LGMS323 Build/KOT49I.MS32310c) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/69.0.3477.0 Mobile Safari/537.36",
                 ViewPort = new ViewPortOptions
                 {
                     Width = 384,
@@ -432,7 +586,7 @@ namespace PuppeteerSharp.Mobile
             [DeviceDescriptorName.LGOptimusL70Landscape] = new DeviceDescriptor
             {
                 Name = "LG Optimus L70 landscape",
-                UserAgent = "Mozilla/5.0 (Linux; U; Android 4.4.2; en-us; LGMS323 Build/KOT49I.MS32310c) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/%s Mobile Safari/537.36",
+                UserAgent = "Mozilla/5.0 (Linux; U; Android 4.4.2; en-us; LGMS323 Build/KOT49I.MS32310c) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/69.0.3477.0 Mobile Safari/537.36",
                 ViewPort = new ViewPortOptions
                 {
                     Width = 640,
@@ -488,7 +642,7 @@ namespace PuppeteerSharp.Mobile
             [DeviceDescriptorName.Nexus10] = new DeviceDescriptor
             {
                 Name = "Nexus 10",
-                UserAgent = "Mozilla/5.0 (Linux; Android 4.3; Nexus 10 Build/JSS15Q) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/%s Safari/537.36",
+                UserAgent = "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 10 Build/MOB31T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3477.0 Safari/537.36",
                 ViewPort = new ViewPortOptions
                 {
                     Width = 800,
@@ -502,7 +656,7 @@ namespace PuppeteerSharp.Mobile
             [DeviceDescriptorName.Nexus10Landscape] = new DeviceDescriptor
             {
                 Name = "Nexus 10 landscape",
-                UserAgent = "Mozilla/5.0 (Linux; Android 4.3; Nexus 10 Build/JSS15Q) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/%s Safari/537.36",
+                UserAgent = "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 10 Build/MOB31T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3477.0 Safari/537.36",
                 ViewPort = new ViewPortOptions
                 {
                     Width = 1280,
@@ -516,7 +670,7 @@ namespace PuppeteerSharp.Mobile
             [DeviceDescriptorName.Nexus4] = new DeviceDescriptor
             {
                 Name = "Nexus 4",
-                UserAgent = "Mozilla/5.0 (Linux; Android 4.4.2; Nexus 4 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/%s Mobile Safari/537.36",
+                UserAgent = "Mozilla/5.0 (Linux; Android 4.4.2; Nexus 4 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3477.0 Mobile Safari/537.36",
                 ViewPort = new ViewPortOptions
                 {
                     Width = 384,
@@ -530,7 +684,7 @@ namespace PuppeteerSharp.Mobile
             [DeviceDescriptorName.Nexus4Landscape] = new DeviceDescriptor
             {
                 Name = "Nexus 4 landscape",
-                UserAgent = "Mozilla/5.0 (Linux; Android 4.4.2; Nexus 4 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/%s Mobile Safari/537.36",
+                UserAgent = "Mozilla/5.0 (Linux; Android 4.4.2; Nexus 4 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3477.0 Mobile Safari/537.36",
                 ViewPort = new ViewPortOptions
                 {
                     Width = 640,
@@ -544,7 +698,7 @@ namespace PuppeteerSharp.Mobile
             [DeviceDescriptorName.Nexus5] = new DeviceDescriptor
             {
                 Name = "Nexus 5",
-                UserAgent = "Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/%s Mobile Safari/537.36",
+                UserAgent = "Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3477.0 Mobile Safari/537.36",
                 ViewPort = new ViewPortOptions
                 {
                     Width = 360,
@@ -558,7 +712,7 @@ namespace PuppeteerSharp.Mobile
             [DeviceDescriptorName.Nexus5Landscape] = new DeviceDescriptor
             {
                 Name = "Nexus 5 landscape",
-                UserAgent = "Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/%s Mobile Safari/537.36",
+                UserAgent = "Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3477.0 Mobile Safari/537.36",
                 ViewPort = new ViewPortOptions
                 {
                     Width = 640,
@@ -572,7 +726,7 @@ namespace PuppeteerSharp.Mobile
             [DeviceDescriptorName.Nexus5X] = new DeviceDescriptor
             {
                 Name = "Nexus 5X",
-                UserAgent = "Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/%s Mobile Safari/537.36",
+                UserAgent = "Mozilla/5.0 (Linux; Android 8.0.0; Nexus 5X Build/OPR4.170623.006) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3477.0 Mobile Safari/537.36",
                 ViewPort = new ViewPortOptions
                 {
                     Width = 412,
@@ -586,7 +740,7 @@ namespace PuppeteerSharp.Mobile
             [DeviceDescriptorName.Nexus5XLandscape] = new DeviceDescriptor
             {
                 Name = "Nexus 5X landscape",
-                UserAgent = "Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/%s Mobile Safari/537.36",
+                UserAgent = "Mozilla/5.0 (Linux; Android 8.0.0; Nexus 5X Build/OPR4.170623.006) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3477.0 Mobile Safari/537.36",
                 ViewPort = new ViewPortOptions
                 {
                     Width = 732,
@@ -600,7 +754,7 @@ namespace PuppeteerSharp.Mobile
             [DeviceDescriptorName.Nexus6] = new DeviceDescriptor
             {
                 Name = "Nexus 6",
-                UserAgent = "Mozilla/5.0 (Linux; Android 5.1.1; Nexus 6 Build/LYZ28E) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/%s Mobile Safari/537.36",
+                UserAgent = "Mozilla/5.0 (Linux; Android 7.1.1; Nexus 6 Build/N6F26U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3477.0 Mobile Safari/537.36",
                 ViewPort = new ViewPortOptions
                 {
                     Width = 412,
@@ -614,7 +768,7 @@ namespace PuppeteerSharp.Mobile
             [DeviceDescriptorName.Nexus6Landscape] = new DeviceDescriptor
             {
                 Name = "Nexus 6 landscape",
-                UserAgent = "Mozilla/5.0 (Linux; Android 5.1.1; Nexus 6 Build/LYZ28E) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/%s Mobile Safari/537.36",
+                UserAgent = "Mozilla/5.0 (Linux; Android 7.1.1; Nexus 6 Build/N6F26U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3477.0 Mobile Safari/537.36",
                 ViewPort = new ViewPortOptions
                 {
                     Width = 732,
@@ -628,7 +782,7 @@ namespace PuppeteerSharp.Mobile
             [DeviceDescriptorName.Nexus6P] = new DeviceDescriptor
             {
                 Name = "Nexus 6P",
-                UserAgent = "Mozilla/5.0 (Linux; Android 5.1.1; Nexus 6 Build/LYZ28E) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/%s Mobile Safari/537.36",
+                UserAgent = "Mozilla/5.0 (Linux; Android 8.0.0; Nexus 6P Build/OPP3.170518.006) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3477.0 Mobile Safari/537.36",
                 ViewPort = new ViewPortOptions
                 {
                     Width = 412,
@@ -642,7 +796,7 @@ namespace PuppeteerSharp.Mobile
             [DeviceDescriptorName.Nexus6PLandscape] = new DeviceDescriptor
             {
                 Name = "Nexus 6P landscape",
-                UserAgent = "Mozilla/5.0 (Linux; Android 5.1.1; Nexus 6 Build/LYZ28E) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/%s Mobile Safari/537.36",
+                UserAgent = "Mozilla/5.0 (Linux; Android 8.0.0; Nexus 6P Build/OPP3.170518.006) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3477.0 Mobile Safari/537.36",
                 ViewPort = new ViewPortOptions
                 {
                     Width = 732,
@@ -656,7 +810,7 @@ namespace PuppeteerSharp.Mobile
             [DeviceDescriptorName.Nexus7] = new DeviceDescriptor
             {
                 Name = "Nexus 7",
-                UserAgent = "Mozilla/5.0 (Linux; Android 4.3; Nexus 7 Build/JSS15Q) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/%s Safari/537.36",
+                UserAgent = "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 7 Build/MOB30X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3477.0 Safari/537.36",
                 ViewPort = new ViewPortOptions
                 {
                     Width = 600,
@@ -670,7 +824,7 @@ namespace PuppeteerSharp.Mobile
             [DeviceDescriptorName.Nexus7Landscape] = new DeviceDescriptor
             {
                 Name = "Nexus 7 landscape",
-                UserAgent = "Mozilla/5.0 (Linux; Android 4.3; Nexus 7 Build/JSS15Q) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/%s Safari/537.36",
+                UserAgent = "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 7 Build/MOB30X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3477.0 Safari/537.36",
                 ViewPort = new ViewPortOptions
                 {
                     Width = 960,
@@ -740,7 +894,7 @@ namespace PuppeteerSharp.Mobile
             [DeviceDescriptorName.Pixel2] = new DeviceDescriptor
             {
                 Name = "Pixel 2",
-                UserAgent = "Mozilla/5.0 (Linux; Android 8.0; Pixel 2 Build/OPD3.170816.012) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.181 Mobile Safari/537.36",
+                UserAgent = "Mozilla/5.0 (Linux; Android 8.0; Pixel 2 Build/OPD3.170816.012) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3477.0 Mobile Safari/537.36",
                 ViewPort = new ViewPortOptions
                 {
                     Width = 411,
@@ -754,7 +908,7 @@ namespace PuppeteerSharp.Mobile
             [DeviceDescriptorName.Pixel2Landscape] = new DeviceDescriptor
             {
                 Name = "Pixel 2 landscape",
-                UserAgent = "Mozilla/5.0 (Linux; Android 8.0; Pixel 2 Build/OPD3.170816.012) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.181 Mobile Safari/537.36",
+                UserAgent = "Mozilla/5.0 (Linux; Android 8.0; Pixel 2 Build/OPD3.170816.012) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3477.0 Mobile Safari/537.36",
                 ViewPort = new ViewPortOptions
                 {
                     Width = 731,
@@ -768,7 +922,7 @@ namespace PuppeteerSharp.Mobile
             [DeviceDescriptorName.Pixel2XL] = new DeviceDescriptor
             {
                 Name = "Pixel 2 XL",
-                UserAgent = "Mozilla/5.0 (Linux; Android 8.0.0; Pixel 2 XL Build/OPD1.170816.004) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.181 Mobile Safari/537.36",
+                UserAgent = "Mozilla/5.0 (Linux; Android 8.0.0; Pixel 2 XL Build/OPD1.170816.004) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3477.0 Mobile Safari/537.36",
                 ViewPort = new ViewPortOptions
                 {
                     Width = 411,
@@ -782,7 +936,7 @@ namespace PuppeteerSharp.Mobile
             [DeviceDescriptorName.Pixel2XLLandscape] = new DeviceDescriptor
             {
                 Name = "Pixel 2 XL landscape",
-                UserAgent = "Mozilla/5.0 (Linux; Android 8.0.0; Pixel 2 XL Build/OPD1.170816.004) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.181 Mobile Safari/537.36",
+                UserAgent = "Mozilla/5.0 (Linux; Android 8.0.0; Pixel 2 XL Build/OPD1.170816.004) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3477.0 Mobile Safari/537.36",
                 ViewPort = new ViewPortOptions
                 {
                     Width = 823,
@@ -794,12 +948,5 @@ namespace PuppeteerSharp.Mobile
                 }
             }
         };
-
-        /// <summary>
-        /// Get the specified device description.
-        /// </summary>
-        /// <returns>The device descriptor.</returns>
-        /// <param name="name">Device Name.</param>
-        public static DeviceDescriptor Get(DeviceDescriptorName name) => Devices[name];
     }
 }

--- a/lib/PuppeteerSharp/Mobile/DeviceDescriptors.cs
+++ b/lib/PuppeteerSharp/Mobile/DeviceDescriptors.cs
@@ -948,5 +948,12 @@ namespace PuppeteerSharp.Mobile
                 }
             }
         };
+            
+        /// <summary>	
+        /// Get the specified device description.	
+        /// </summary>	
+        /// <returns>The device descriptor.</returns>	
+        /// <param name="name">Device Name.</param>	
+        public static DeviceDescriptor Get(DeviceDescriptorName name) => Devices[name];
     }
 }


### PR DESCRIPTION
closes #478 

todos:
- [x] generate a cs file instead of js
- [x] cleanup puppeteer `ExecutablePath` argument
- [x] cleanup `Main` method