### PR TITLE
Concurrency improvements

### DIFF
--- a/lib/PuppeteerSharp.Tests/ElementHandleTests/BoundingBoxTests.cs
+++ b/lib/PuppeteerSharp.Tests/ElementHandleTests/BoundingBoxTests.cs
@@ -34,8 +34,8 @@ namespace PuppeteerSharp.Tests.ElementHandleTests
                 Width = 500,
                 Height = 500
             });
-            await Page.GoToAsync(TestConstants.ServerUrl + "/frames/nested-frames.html");
-            var childFrame = Page.FirstChildFrame();
+            await Page.GoToAsync(TestConstants.ServerUrl + "/frames/nested-frames.html", WaitUntilNavigation.Networkidle0);
+            var childFrame = Page.Frames.First(f => f.Url.Contains("two-frames.html"));
             var nestedFrame = childFrame.ChildFrames.Last();
             var elementHandle = await nestedFrame.QuerySelectorAsync("div");
             var box = await elementHandle.BoundingBoxAsync();

--- a/lib/PuppeteerSharp.Tests/ElementHandleTests/BoundingBoxTests.cs
+++ b/lib/PuppeteerSharp.Tests/ElementHandleTests/BoundingBoxTests.cs
@@ -36,7 +36,7 @@ namespace PuppeteerSharp.Tests.ElementHandleTests
             });
             await Page.GoToAsync(TestConstants.ServerUrl + "/frames/nested-frames.html");
             var childFrame = Page.FirstChildFrame();
-            var nestedFrame = childFrame.ChildFrames.First(f => f.ParentFrame == childFrame);
+            var nestedFrame = childFrame.ChildFrames.Last();
             var elementHandle = await nestedFrame.QuerySelectorAsync("div");
             var box = await elementHandle.BoundingBoxAsync();
             Assert.Equal(new BoundingBox(28, 260, 264, 18), box);

--- a/lib/PuppeteerSharp.Tests/ElementHandleTests/BoundingBoxTests.cs
+++ b/lib/PuppeteerSharp.Tests/ElementHandleTests/BoundingBoxTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Linq;
+using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -34,7 +35,8 @@ namespace PuppeteerSharp.Tests.ElementHandleTests
                 Height = 500
             });
             await Page.GoToAsync(TestConstants.ServerUrl + "/frames/nested-frames.html");
-            var nestedFrame = Page.Frames[1].ChildFrames[1];
+            var childFrame = Page.FirstChildFrame();
+            var nestedFrame = childFrame.ChildFrames.First(f => f.ParentFrame != childFrame);
             var elementHandle = await nestedFrame.QuerySelectorAsync("div");
             var box = await elementHandle.BoundingBoxAsync();
             Assert.Equal(new BoundingBox(28, 260, 264, 18), box);

--- a/lib/PuppeteerSharp.Tests/ElementHandleTests/BoundingBoxTests.cs
+++ b/lib/PuppeteerSharp.Tests/ElementHandleTests/BoundingBoxTests.cs
@@ -36,7 +36,7 @@ namespace PuppeteerSharp.Tests.ElementHandleTests
             });
             await Page.GoToAsync(TestConstants.ServerUrl + "/frames/nested-frames.html");
             var childFrame = Page.FirstChildFrame();
-            var nestedFrame = childFrame.ChildFrames.First(f => f.ParentFrame != childFrame);
+            var nestedFrame = childFrame.ChildFrames.First(f => f.ParentFrame == childFrame);
             var elementHandle = await nestedFrame.QuerySelectorAsync("div");
             var box = await elementHandle.BoundingBoxAsync();
             Assert.Equal(new BoundingBox(28, 260, 264, 18), box);

--- a/lib/PuppeteerSharp.Tests/ElementHandleTests/BoxModelTests.cs
+++ b/lib/PuppeteerSharp.Tests/ElementHandleTests/BoxModelTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Linq;
+using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -27,7 +28,7 @@ namespace PuppeteerSharp.Tests.ElementHandleTests
               `;");
 
             // Step 2: Add div and position it absolutely inside frame.
-            var frame = Page.Frames[1];
+            var frame = Page.FirstChildFrame();
             var divHandle = (await frame.EvaluateFunctionHandleAsync(@"() => {
               const div = document.createElement('div');
               document.body.appendChild(div);

--- a/lib/PuppeteerSharp.Tests/ElementHandleTests/ContentFrameTests.cs
+++ b/lib/PuppeteerSharp.Tests/ElementHandleTests/ContentFrameTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Linq;
+using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -18,7 +19,7 @@ namespace PuppeteerSharp.Tests.ElementHandleTests
             await FrameUtils.AttachFrameAsync(Page, "frame1", TestConstants.EmptyPage);
             var elementHandle = await Page.QuerySelectorAsync("#frame1");
             var frame = await elementHandle.ContentFrameAsync();
-            Assert.Equal(Page.Frames[1], frame);
+            Assert.Equal(Page.FirstChildFrame(), frame);
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/FrameTests/EvaluateTests.cs
+++ b/lib/PuppeteerSharp.Tests/FrameTests/EvaluateTests.cs
@@ -20,7 +20,7 @@ namespace PuppeteerSharp.Tests.FrameTests
             Assert.Equal(2, Page.Frames.Count());
 
             var frame1 = Page.Frames.ElementAt(0);
-            var frame2 = Page.Frames.ElementAt(1);
+            var frame2 = Page.FirstChildFrame();
 
             await frame1.EvaluateExpressionAsync("window.FOO = 'foo'");
             await frame2.EvaluateExpressionAsync("window.FOO = 'bar'");

--- a/lib/PuppeteerSharp.Tests/FrameTests/EvaluateTests.cs
+++ b/lib/PuppeteerSharp.Tests/FrameTests/EvaluateTests.cs
@@ -19,7 +19,7 @@ namespace PuppeteerSharp.Tests.FrameTests
             await FrameUtils.AttachFrameAsync(Page, "frame1", TestConstants.EmptyPage);
             Assert.Equal(2, Page.Frames.Count());
 
-            var frame1 = Page.Frames.ElementAt(0);
+            var frame1 = Page.MainFrame;
             var frame2 = Page.FirstChildFrame();
 
             await frame1.EvaluateExpressionAsync("window.FOO = 'foo'");

--- a/lib/PuppeteerSharp.Tests/FrameTests/ExecutionContextTests.cs
+++ b/lib/PuppeteerSharp.Tests/FrameTests/ExecutionContextTests.cs
@@ -18,13 +18,13 @@ namespace PuppeteerSharp.Tests.FrameTests
             await FrameUtils.AttachFrameAsync(Page, "frame1", TestConstants.EmptyPage);
             Assert.Equal(2, Page.Frames.Length);
 
-            var context1 = await Page.Frames[0].GetExecutionContextAsync();
-            var context2 = await Page.Frames[1].GetExecutionContextAsync();
+            var context1 = await Page.MainFrame.GetExecutionContextAsync();
+            var context2 = await Page.FirstChildFrame().GetExecutionContextAsync();
             Assert.NotNull(context1);
             Assert.NotNull(context2);
             Assert.NotEqual(context1, context2);
-            Assert.Equal(Page.Frames[0], context1.Frame);
-            Assert.Equal(Page.Frames[1], context2.Frame);
+            Assert.Equal(Page.MainFrame, context1.Frame);
+            Assert.Equal(Page.FirstChildFrame(), context2.Frame);
 
             await Task.WhenAll(
                 context1.EvaluateExpressionAsync("window.a = 1"),

--- a/lib/PuppeteerSharp.Tests/FrameTests/FrameManagementTests.cs
+++ b/lib/PuppeteerSharp.Tests/FrameTests/FrameManagementTests.cs
@@ -18,7 +18,7 @@ namespace PuppeteerSharp.Tests.FrameTests
         {
             await Page.GoToAsync(TestConstants.ServerUrl + "/frames/nested-frames.html");
             Assert.Equal(
-                TestUtils.CompressText(TestConstants.NestedFramesDumpResult), 
+                TestUtils.CompressText(TestConstants.NestedFramesDumpResult),
                 TestUtils.CompressText(FrameUtils.DumpFrames(Page.MainFrame)));
         }
 
@@ -124,9 +124,9 @@ namespace PuppeteerSharp.Tests.FrameTests
                 return new Promise(x => frame.onload = x);
             }", TestConstants.EmptyPage);
 
-            Assert.Equal(string.Empty, Page.Frames.ElementAt(0).Name);
-            Assert.Equal("theFrameId", Page.Frames.ElementAt(1).Name);
-            Assert.Equal("theFrameName", Page.Frames.ElementAt(2).Name);
+            Assert.Single(Page.Frames.Where(f => f.Name == string.Empty));
+            Assert.Single(Page.Frames.Where(f => f.Name == "theFrameId"));
+            Assert.Single(Page.Frames.Where(f => f.Name == "theFrameName"));
         }
 
         [Fact]
@@ -135,9 +135,8 @@ namespace PuppeteerSharp.Tests.FrameTests
             await FrameUtils.AttachFrameAsync(Page, "frame1", TestConstants.EmptyPage);
             await FrameUtils.AttachFrameAsync(Page, "frame2", TestConstants.EmptyPage);
 
-            Assert.Null(Page.Frames.ElementAt(0).ParentFrame);
-            Assert.Equal(Page.MainFrame, Page.Frames.ElementAt(1).ParentFrame);
-            Assert.Equal(Page.MainFrame, Page.Frames.ElementAt(2).ParentFrame);
+            Assert.Single(Page.Frames.Where(f => f.ParentFrame == null));
+            Assert.Equal(2, Page.Frames.Count(f => f.ParentFrame == Page.MainFrame));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/FrameTests/FrameManagementTests.cs
+++ b/lib/PuppeteerSharp.Tests/FrameTests/FrameManagementTests.cs
@@ -124,9 +124,9 @@ namespace PuppeteerSharp.Tests.FrameTests
                 return new Promise(x => frame.onload = x);
             }", TestConstants.EmptyPage);
 
-            Assert.Single(Page.Frames.Where(f => f.Name == string.Empty));
-            Assert.Single(Page.Frames.Where(f => f.Name == "theFrameId"));
-            Assert.Single(Page.Frames.Where(f => f.Name == "theFrameName"));
+            Assert.Single(Page.Frames, frame => frame.Name == string.Empty);
+            Assert.Single(Page.Frames, frame => frame.Name == "theFrameId");
+            Assert.Single(Page.Frames, frame => frame.Name == "theFrameName");
         }
 
         [Fact]
@@ -135,7 +135,7 @@ namespace PuppeteerSharp.Tests.FrameTests
             await FrameUtils.AttachFrameAsync(Page, "frame1", TestConstants.EmptyPage);
             await FrameUtils.AttachFrameAsync(Page, "frame2", TestConstants.EmptyPage);
 
-            Assert.Single(Page.Frames.Where(f => f.ParentFrame == null));
+            Assert.Single(Page.Frames, frame => frame.ParentFrame == null);
             Assert.Equal(2, Page.Frames.Count(f => f.ParentFrame == Page.MainFrame));
         }
     }

--- a/lib/PuppeteerSharp.Tests/FrameTests/WaitForNavigationTests.cs
+++ b/lib/PuppeteerSharp.Tests/FrameTests/WaitForNavigationTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Net;
+﻿using System.Linq;
+using System.Net;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
@@ -16,7 +17,7 @@ namespace PuppeteerSharp.Tests.FrameTests
         public async Task ShouldWork()
         {
             await Page.GoToAsync(TestConstants.ServerUrl + "/frames/one-frame.html");
-            var frame = Page.Frames[1];
+            var frame = Page.FirstChildFrame();
             var waitForNavigationResult = frame.WaitForNavigationAsync();
 
             await Task.WhenAll(
@@ -25,7 +26,7 @@ namespace PuppeteerSharp.Tests.FrameTests
             );
             var response = await waitForNavigationResult;
             Assert.Equal(HttpStatusCode.OK, response.Status);
-            Assert.Contains("grid.html", response.Url); 
+            Assert.Contains("grid.html", response.Url);
             Assert.Same(frame, response.Frame);
             Assert.Contains("/frames/one-frame.html", Page.Url);
         }
@@ -34,7 +35,7 @@ namespace PuppeteerSharp.Tests.FrameTests
         public async Task ShouldRejectWhenFrameDetaches()
         {
             await Page.GoToAsync(TestConstants.ServerUrl + "/frames/one-frame.html");
-            var frame = Page.Frames[1];
+            var frame = Page.FirstChildFrame();
             Server.SetRoute("/empty.html", context => Task.Delay(10000));
             var waitForNavigationResult = frame.WaitForNavigationAsync();
             await Task.WhenAll(
@@ -43,6 +44,6 @@ namespace PuppeteerSharp.Tests.FrameTests
 
             await Page.QuerySelectorAsync("iframe").EvaluateFunctionAsync("frame => frame.remove()");
             var response = await waitForNavigationResult;
-        } 
+        }
     }
 }

--- a/lib/PuppeteerSharp.Tests/FrameTests/WaitForSelectorTests.cs
+++ b/lib/PuppeteerSharp.Tests/FrameTests/WaitForSelectorTests.cs
@@ -53,7 +53,7 @@ namespace PuppeteerSharp.Tests.FrameTests
         {
             await Page.GoToAsync(TestConstants.EmptyPage);
             await FrameUtils.AttachFrameAsync(Page, "frame1", TestConstants.EmptyPage);
-            var otherFrame = Page.Frames.ElementAt(1);
+            var otherFrame = Page.FirstChildFrame();
             var watchdog = Page.WaitForSelectorAsync("div");
             await otherFrame.EvaluateFunctionAsync(AddElement, "div");
             await Page.EvaluateFunctionAsync(AddElement, "div");
@@ -66,7 +66,7 @@ namespace PuppeteerSharp.Tests.FrameTests
         {
             await FrameUtils.AttachFrameAsync(Page, "frame1", TestConstants.EmptyPage);
             await FrameUtils.AttachFrameAsync(Page, "frame2", TestConstants.EmptyPage);
-            var frame1 = Page.Frames.ElementAt(1);
+            var frame1 = Page.FirstChildFrame();
             var frame2 = Page.Frames.ElementAt(2);
             var waitForSelectorPromise = frame2.WaitForSelectorAsync("div");
             await frame1.EvaluateFunctionAsync(AddElement, "div");
@@ -90,7 +90,7 @@ namespace PuppeteerSharp.Tests.FrameTests
         public async Task ShouldThrowWhenFrameIsDetached()
         {
             await FrameUtils.AttachFrameAsync(Page, "frame1", TestConstants.EmptyPage);
-            var frame = Page.Frames.ElementAt(1);
+            var frame = Page.FirstChildFrame();
             var waitTask = frame.WaitForSelectorAsync(".box").ContinueWith(task => task?.Exception?.InnerException);
             await FrameUtils.DetachFrameAsync(Page, "frame1");
             var waitException = await waitTask;

--- a/lib/PuppeteerSharp.Tests/FrameTests/WaitForXPathTests.cs
+++ b/lib/PuppeteerSharp.Tests/FrameTests/WaitForXPathTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
@@ -27,8 +28,8 @@ namespace PuppeteerSharp.Tests.FrameTests
         {
             await FrameUtils.AttachFrameAsync(Page, "frame1", TestConstants.EmptyPage);
             await FrameUtils.AttachFrameAsync(Page, "frame2", TestConstants.EmptyPage);
-            var frame1 = Page.Frames[1];
-            var frame2 = Page.Frames[2];
+            var frame1 = Page.Frames.First(f => f.Name == "frame1");
+            var frame2 = Page.Frames.First(f => f.Name == "frame2");
             var waitForXPathPromise = frame2.WaitForXPathAsync("//div");
             await frame1.EvaluateFunctionAsync(addElement, "div");
             await frame2.EvaluateFunctionAsync(addElement, "div");
@@ -52,7 +53,7 @@ namespace PuppeteerSharp.Tests.FrameTests
         public async Task ShouldThrowWhenFrameIsDetached()
         {
             await FrameUtils.AttachFrameAsync(Page, "frame1", TestConstants.EmptyPage);
-            var frame = Page.Frames[1];
+            var frame = Page.FirstChildFrame();
             var waitPromise = frame.WaitForXPathAsync("//*[@class=\"box\"]");
             await FrameUtils.DetachFrameAsync(Page, "frame1");
             var exception = await Assert.ThrowsAnyAsync<Exception>(() => waitPromise);

--- a/lib/PuppeteerSharp.Tests/InputTests/InputTests.cs
+++ b/lib/PuppeteerSharp.Tests/InputTests/InputTests.cs
@@ -547,7 +547,7 @@ namespace PuppeteerSharp.Tests.InputTests
             await Page.GoToAsync(TestConstants.EmptyPage);
             await Page.SetContentAsync("<div style=\"width:100px;height:100px\">spacer</div>");
             await FrameUtils.AttachFrameAsync(Page, "button-test", TestConstants.ServerUrl + "/input/button.html");
-            var frame = Page.Frames[1];
+            var frame = Page.FirstChildFrame();
             var button = await frame.QuerySelectorAsync("button");
             await button.ClickAsync();
             Assert.Equal("Clicked", await frame.EvaluateExpressionAsync<string>("window.result"));
@@ -560,7 +560,7 @@ namespace PuppeteerSharp.Tests.InputTests
             Assert.Equal(5, await Page.EvaluateExpressionAsync<int>("window.devicePixelRatio"));
             await Page.SetContentAsync("<div style=\"width:100px;height:100px\">spacer</div>");
             await FrameUtils.AttachFrameAsync(Page, "button-test", TestConstants.ServerUrl + "/input/button.html");
-            var frame = Page.Frames[1];
+            var frame = Page.FirstChildFrame();
             var button = await frame.QuerySelectorAsync("button");
             await button.ClickAsync();
             Assert.Equal("Clicked", await frame.EvaluateExpressionAsync<string>("window.result"));
@@ -623,7 +623,7 @@ namespace PuppeteerSharp.Tests.InputTests
         {
             await Page.GoToAsync(TestConstants.EmptyPage);
             await FrameUtils.AttachFrameAsync(Page, "emoji-test", TestConstants.ServerUrl + "/input/textarea.html");
-            var frame = Page.Frames[1];
+            var frame = Page.FirstChildFrame();
             var textarea = await frame.QuerySelectorAsync("textarea");
             await textarea.TypeAsync("👹 Tokyo street Japan \uD83C\uDDEF\uD83C\uDDF5");
             Assert.Equal(

--- a/lib/PuppeteerSharp.Tests/PageExtensions.cs
+++ b/lib/PuppeteerSharp.Tests/PageExtensions.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Linq;
+
+namespace PuppeteerSharp.Tests
+{
+    public static class PageExtensions
+    {
+        public static Frame FirstChildFrame(this Page page) => page.Frames.FirstOrDefault(f => f.ParentFrame == page.MainFrame);
+    }
+}

--- a/lib/PuppeteerSharp.Tests/PageTests/CookiesTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/CookiesTests.cs
@@ -184,7 +184,7 @@ namespace PuppeteerSharp.Tests.PageTests
                 }", TestConstants.CrossProcessHttpPrefix);
             await Page.SetCookieAsync(new CookieParam { Name = "127-cookie", Value = "worst", Url = TestConstants.CrossProcessHttpPrefix });
             Assert.Equal("localhost-cookie=best", await Page.EvaluateExpressionAsync<string>("document.cookie"));
-            Assert.Equal("127-cookie=worst", await Page.Frames.ElementAt(1).EvaluateExpressionAsync<string>("document.cookie"));
+            Assert.Equal("127-cookie=worst", await Page.FirstChildFrame().EvaluateExpressionAsync<string>("document.cookie"));
             var cookie = Assert.Single(await Page.GetCookiesAsync());
             Assert.Equal("localhost-cookie", cookie.Name);
             Assert.Equal("best", cookie.Value);

--- a/lib/PuppeteerSharp.Tests/PageTests/EvaluateTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/EvaluateTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using Xunit;
@@ -136,7 +137,7 @@ namespace PuppeteerSharp.Tests.PageTests
         public async Task ShouldThrowIfElementHandlesAreFromOtherFrames()
         {
             await FrameUtils.AttachFrameAsync(Page, "frame1", TestConstants.EmptyPage);
-            var bodyHandle = await Page.Frames[1].QuerySelectorAsync("body");
+            var bodyHandle = await Page.FirstChildFrame().QuerySelectorAsync("body");
             var exception = await Assert.ThrowsAsync<EvaluationFailedException>(()
                 => Page.EvaluateFunctionAsync<string>("body => body.innerHTML", bodyHandle));
             Assert.Contains("JSHandles can be evaluated only in the context they were created", exception.Message);

--- a/lib/PuppeteerSharp.Tests/PageTests/Events/RequestTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/Events/RequestTests.cs
@@ -29,7 +29,7 @@ namespace PuppeteerSharp.Tests.PageTests.Events
             Assert.Equal(TestConstants.EmptyPage, requests[0].Frame.Url);
 
             Assert.Equal(TestConstants.EmptyPage, requests[1].Url);
-            Assert.Equal(Page.Frames.ElementAt(1), requests[1].Frame);
+            Assert.Equal(Page.FirstChildFrame(), requests[1].Frame);
             Assert.Equal(TestConstants.EmptyPage, requests[1].Frame.Url);
         }
     }

--- a/lib/PuppeteerSharp.Tests/PageTests/ExposeFunctionTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/ExposeFunctionTests.cs
@@ -41,7 +41,7 @@ namespace PuppeteerSharp.Tests.PageTests
         {
             await Page.ExposeFunctionAsync("compute", (int a, int b) => Task.FromResult(a * b));
             await Page.GoToAsync(TestConstants.ServerUrl + "/frames/nested-frames.html");
-            var frame = Page.Frames[1];
+            var frame = Page.FirstChildFrame();
             var result = await frame.EvaluateExpressionAsync<int>("compute(3, 5)");
             Assert.Equal(15, result);
         }
@@ -52,7 +52,7 @@ namespace PuppeteerSharp.Tests.PageTests
             await Page.GoToAsync(TestConstants.ServerUrl + "/frames/nested-frames.html");
             await Page.ExposeFunctionAsync("compute", (int a, int b) => Task.FromResult(a * b));
 
-            var frame = Page.Frames[1];
+            var frame = Page.FirstChildFrame();
             var result = await frame.EvaluateExpressionAsync<int>("compute(3, 5)");
             Assert.Equal(15, result);
         }

--- a/lib/PuppeteerSharp.Tests/PuppeteerTests/IgnoreHttpsErrorsTests.cs
+++ b/lib/PuppeteerSharp.Tests/PuppeteerTests/IgnoreHttpsErrorsTests.cs
@@ -69,8 +69,8 @@ namespace PuppeteerSharp.Tests.PuppeteerTests
             Assert.Equal(2, Page.Frames.Length);
             // Make sure blocked iframe has functional execution context
             // @see https://github.com/GoogleChrome/puppeteer/issues/2709
-            Assert.Equal(3, await Page.Frames[0].EvaluateExpressionAsync<int>("1 + 2"));
-            Assert.Equal(5, await Page.Frames[1].EvaluateExpressionAsync<int>("2 + 3"));
+            Assert.Equal(3, await Page.MainFrame.EvaluateExpressionAsync<int>("1 + 2"));
+            Assert.Equal(5, await Page.FirstChildFrame().EvaluateExpressionAsync<int>("2 + 3"));
         }
     }
 }

--- a/lib/PuppeteerSharp/Browser.cs
+++ b/lib/PuppeteerSharp/Browser.cs
@@ -74,7 +74,7 @@ namespace PuppeteerSharp
 
         #region Private members
 
-        internal readonly ConcurrentDictionary<string, Target> TargetsMap;
+        internal readonly IDictionary<string, Target> TargetsMap;
 
         private readonly Dictionary<string, BrowserContext> _contexts;
         private readonly ILogger<Browser> _logger;
@@ -365,7 +365,7 @@ namespace PuppeteerSharp
             }
 
             var target = TargetsMap[e.TargetId];
-            TargetsMap.TryRemove(e.TargetId, out _);
+            TargetsMap.Remove(e.TargetId);
 
             target.CloseTaskWrapper.TrySetResult(true);
 

--- a/lib/PuppeteerSharp/Browser.cs
+++ b/lib/PuppeteerSharp/Browser.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -58,7 +59,7 @@ namespace PuppeteerSharp
             Connection = connection;
             IgnoreHTTPSErrors = ignoreHTTPSErrors;
             DefaultViewport = defaultViewport;
-            TargetsMap = new Dictionary<string, Target>();
+            TargetsMap = new ConcurrentDictionary<string, Target>();
             ScreenshotTaskQueue = new TaskQueue();
             DefaultContext = new BrowserContext(Connection, this, null);
             _contexts = contextIds.ToDictionary(keySelector: contextId => contextId,
@@ -73,7 +74,7 @@ namespace PuppeteerSharp
 
         #region Private members
 
-        internal readonly Dictionary<string, Target> TargetsMap;
+        internal readonly ConcurrentDictionary<string, Target> TargetsMap;
 
         private readonly Dictionary<string, BrowserContext> _contexts;
         private readonly ILogger<Browser> _logger;
@@ -364,7 +365,7 @@ namespace PuppeteerSharp
             }
 
             var target = TargetsMap[e.TargetId];
-            TargetsMap.Remove(e.TargetId);
+            TargetsMap.TryRemove(e.TargetId, out _);
 
             target.CloseTaskWrapper.TrySetResult(true);
 

--- a/lib/PuppeteerSharp/ElementHandle.cs
+++ b/lib/PuppeteerSharp/ElementHandle.cs
@@ -389,7 +389,7 @@ namespace PuppeteerSharp
                 { MessageKeys.ObjectId, RemoteObject[MessageKeys.ObjectId] }
             }).ConfigureAwait(false);
 
-            return string.IsNullOrEmpty(nodeInfo.Node.FrameId) ? null : _frameManager.Frames[nodeInfo.Node.FrameId];
+            return string.IsNullOrEmpty(nodeInfo.Node.FrameId) ? null : await _frameManager.GetFrameAsync(nodeInfo.Node.FrameId);
         }
 
         /// <summary>

--- a/lib/PuppeteerSharp/Frame.cs
+++ b/lib/PuppeteerSharp/Frame.cs
@@ -641,7 +641,7 @@ namespace PuppeteerSharp
         {
             if (context != null)
             {
-                _contextResolveTaskWrapper.SetResult(context);
+                _contextResolveTaskWrapper.TrySetResult(context);
 
                 foreach (var waitTask in WaitTasks)
                 {

--- a/lib/PuppeteerSharp/FrameManager.cs
+++ b/lib/PuppeteerSharp/FrameManager.cs
@@ -308,10 +308,10 @@ namespace PuppeteerSharp
             FrameNavigated?.Invoke(this, new FrameEventArgs(frame));
         }
 
-        private void AddFrame(string framId, Frame frame)
+        private void AddFrame(string frameId, Frame frame)
         {
-            _frames[framId] = frame;
-            foreach (var tcs in _pendingFrameRequests.Get(framId))
+            _frames[frameId] = frame;
+            foreach (var tcs in _pendingFrameRequests.Get(frameId))
             {
                 tcs.TrySetResult(frame);
             }

--- a/lib/PuppeteerSharp/FrameManager.cs
+++ b/lib/PuppeteerSharp/FrameManager.cs
@@ -393,7 +393,6 @@ namespace PuppeteerSharp
             }
 
             return await tcs.Task;
-
         }
 
         #endregion

--- a/lib/PuppeteerSharp/FrameManager.cs
+++ b/lib/PuppeteerSharp/FrameManager.cs
@@ -21,7 +21,6 @@ namespace PuppeteerSharp
         private readonly MultiMap<string, TaskCompletionSource<Frame>> _pendingFrameRequests;
         private const int WaitForRequestDelay = 1000;
 
-
         private FrameManager(CDPSession client, Page page, NetworkManager networkManager)
         {
             _client = client;
@@ -56,7 +55,6 @@ namespace PuppeteerSharp
             await frameManager.HandleFrameTreeAsync(frameTree).ConfigureAwait(false);
             return frameManager;
         }
-
 
         internal ExecutionContext ExecutionContextById(int contextId)
         {

--- a/lib/PuppeteerSharp/FrameManager.cs
+++ b/lib/PuppeteerSharp/FrameManager.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using PuppeteerSharp.Helpers;
@@ -15,15 +16,19 @@ namespace PuppeteerSharp
         private bool _ensureNewDocumentNavigation;
         private readonly ILogger _logger;
         private readonly NetworkManager _networkManager;
+        private readonly Dictionary<string, Frame> _frames;
+        private readonly MultiMap<string, TaskCompletionSource<Frame>> _pendingFrameRequests;
+        private const int WaitForRequestDelay = 1000;
 
         internal FrameManager(CDPSession client, FrameTree frameTree, Page page, NetworkManager networkManager)
         {
             _client = client;
             Page = page;
-            Frames = new Dictionary<string, Frame>();
+            _frames = new Dictionary<string, Frame>();
             _contextIdToContext = new Dictionary<int, ExecutionContext>();
             _logger = _client.Connection.LoggerFactory.CreateLogger<FrameManager>();
             _networkManager = networkManager;
+            _pendingFrameRequests = new MultiMap<string, TaskCompletionSource<Frame>>();
 
             _client.MessageReceived += _client_MessageReceived;
             HandleFrameTree(frameTree);
@@ -37,7 +42,6 @@ namespace PuppeteerSharp
         internal event EventHandler<FrameEventArgs> FrameNavigatedWithinDocument;
         internal event EventHandler<FrameEventArgs> LifecycleEvent;
 
-        internal Dictionary<string, Frame> Frames { get; set; }
         internal Frame MainFrame { get; set; }
         internal Page Page { get; }
         internal int DefaultNavigationTimeout { get; set; } = 30000;
@@ -144,7 +148,7 @@ namespace PuppeteerSharp
 
         #region Private Methods
 
-        private void _client_MessageReceived(object sender, MessageEventArgs e)
+        private async void _client_MessageReceived(object sender, MessageEventArgs e)
         {
             switch (e.MessageID)
             {
@@ -171,7 +175,7 @@ namespace PuppeteerSharp
                     break;
 
                 case "Runtime.executionContextCreated":
-                    OnExecutionContextCreated(e.MessageData.SelectToken(MessageKeys.Context).ToObject<ContextPayload>());
+                    await OnExecutionContextCreatedAsync(e.MessageData.SelectToken(MessageKeys.Context).ToObject<ContextPayload>());
                     break;
 
                 case "Runtime.executionContextDestroyed":
@@ -190,7 +194,7 @@ namespace PuppeteerSharp
 
         private void OnFrameStoppedLoading(BasicFrameResponse e)
         {
-            if (Frames.TryGetValue(e.FrameId, out var frame))
+            if (_frames.TryGetValue(e.FrameId, out var frame))
             {
                 frame.OnLoadingStopped();
                 LifecycleEvent?.Invoke(this, new FrameEventArgs(frame));
@@ -199,7 +203,7 @@ namespace PuppeteerSharp
 
         private void OnLifeCycleEvent(LifecycleEventResponse e)
         {
-            if (Frames.TryGetValue(e.FrameId, out var frame))
+            if (_frames.TryGetValue(e.FrameId, out var frame))
             {
                 frame.OnLifecycleEvent(e.LoaderId, e.Name);
                 LifecycleEvent?.Invoke(this, new FrameEventArgs(frame));
@@ -226,10 +230,10 @@ namespace PuppeteerSharp
             }
         }
 
-        private void OnExecutionContextCreated(ContextPayload contextPayload)
+        private async Task OnExecutionContextCreatedAsync(ContextPayload contextPayload)
         {
             var frameId = contextPayload.AuxData.IsDefault ? contextPayload.AuxData.FrameId : null;
-            var frame = !string.IsNullOrEmpty(frameId) ? Frames[frameId] : null;
+            var frame = !string.IsNullOrEmpty(frameId) ? await GetFrameAsync(frameId) : null;
 
             var context = new ExecutionContext(
                 _client,
@@ -246,7 +250,7 @@ namespace PuppeteerSharp
 
         private void OnFrameDetached(BasicFrameResponse e)
         {
-            if (Frames.TryGetValue(e.FrameId, out var frame))
+            if (_frames.TryGetValue(e.FrameId, out var frame))
             {
                 RemoveFramesRecursively(frame);
             }
@@ -255,7 +259,7 @@ namespace PuppeteerSharp
         private void OnFrameNavigated(FramePayload framePayload)
         {
             var isMainFrame = string.IsNullOrEmpty(framePayload.ParentId);
-            var frame = isMainFrame ? MainFrame : Frames[framePayload.Id];
+            var frame = isMainFrame ? MainFrame : _frames[framePayload.Id];
 
             Contract.Assert(isMainFrame || frame != null, "We either navigate top level or have old version of the navigated frame");
 
@@ -276,7 +280,7 @@ namespace PuppeteerSharp
                     // Update frame id to retain frame identity on cross-process navigation.
                     if (frame.Id != null)
                     {
-                        Frames.Remove(frame.Id);
+                        _frames.Remove(frame.Id);
                     }
                     frame.Id = framePayload.Id;
                 }
@@ -285,8 +289,7 @@ namespace PuppeteerSharp
                     // Initial main frame navigation.
                     frame = new Frame(this, _client, null, framePayload.Id);
                 }
-
-                Frames[framePayload.Id] = frame;
+                AddFrame(framePayload.Id, frame);
                 MainFrame = frame;
             }
 
@@ -296,9 +299,20 @@ namespace PuppeteerSharp
             FrameNavigated?.Invoke(this, new FrameEventArgs(frame));
         }
 
+        private void AddFrame(string framId, Frame frame)
+        {
+            _frames[framId] = frame;
+            foreach (var tcs in _pendingFrameRequests.Get(framId))
+            {
+                tcs.TrySetResult(frame);
+            }
+        }
+
+        internal Frame[] GetFrames() => _frames.Values.ToArray();
+
         private void OnFrameNavigatedWithinDocument(NavigatedWithinDocumentResponse e)
         {
-            if (Frames.TryGetValue(e.FrameId, out var frame))
+            if (_frames.TryGetValue(e.FrameId, out var frame))
             {
                 frame.NavigatedWithinDocument(e.Url);
 
@@ -323,17 +337,17 @@ namespace PuppeteerSharp
                 RemoveFramesRecursively(frame.ChildFrames[0]);
             }
             frame.Detach();
-            Frames.Remove(frame.Id);
+            _frames.Remove(frame.Id);
             FrameDetached?.Invoke(this, new FrameEventArgs(frame));
         }
 
         private void OnFrameAttached(string frameId, string parentFrameId)
         {
-            if (!Frames.ContainsKey(frameId) && Frames.ContainsKey(parentFrameId))
+            if (!_frames.ContainsKey(frameId) && _frames.ContainsKey(parentFrameId))
             {
-                var parentFrame = Frames[parentFrameId];
+                var parentFrame = _frames[parentFrameId];
                 var frame = new Frame(this, _client, parentFrame, frameId);
-                Frames[frame.Id] = frame;
+                _frames[frame.Id] = frame;
                 FrameAttached?.Invoke(this, new FrameEventArgs(frame));
             }
         }
@@ -354,6 +368,32 @@ namespace PuppeteerSharp
                     HandleFrameTree(child);
                 }
             }
+        }
+
+        internal async Task<Frame> GetFrameAsync(string frameId)
+        {
+            var tcs = new TaskCompletionSource<Frame>();
+            _pendingFrameRequests.Add(frameId, tcs);
+
+            if (_frames.TryGetValue(frameId, out var frame))
+            {
+                _pendingFrameRequests.Delete(frameId, tcs);
+                return frame;
+            }
+
+            var delayTask = Task.Delay(WaitForRequestDelay);
+            var task = Task.WhenAny(
+                delayTask,
+                tcs.Task
+            );
+
+            if (task == delayTask)
+            {
+                throw new PuppeteerException($"Frame '{frameId}' not found");
+            }
+
+            return await tcs.Task;
+
         }
 
         #endregion

--- a/lib/PuppeteerSharp/Helpers/MultiMap.cs
+++ b/lib/PuppeteerSharp/Helpers/MultiMap.cs
@@ -6,7 +6,7 @@ namespace PuppeteerSharp.Helpers
 {
     internal class MultiMap<TKey, TValue>
     {
-        private readonly ConcurrentDictionary<TKey, HashSet<TValue>> _map = new ConcurrentDictionary<TKey, HashSet<TValue>>();
+        private readonly ConcurrentDictionary<TKey, List<TValue>> _map = new ConcurrentDictionary<TKey, List<TValue>>();
 
         internal void Add(TKey key, TValue value)
         {
@@ -16,13 +16,13 @@ namespace PuppeteerSharp.Helpers
             }
             else
             {
-                set = new HashSet<TValue> { value };
+                set = new List<TValue> { value };
                 _map.TryAdd(key, set);
             }
         }
 
-        internal HashSet<TValue> Get(TKey key)
-            => _map.TryGetValue(key, out var set) ? set : new HashSet<TValue>();
+        internal List<TValue> Get(TKey key)
+            => _map.TryGetValue(key, out var set) ? set : new List<TValue>();
 
         internal bool Has(TKey key, TValue value)
             => _map.TryGetValue(key, out var set) && set.Contains(value);

--- a/lib/PuppeteerSharp/Helpers/MultiMap.cs
+++ b/lib/PuppeteerSharp/Helpers/MultiMap.cs
@@ -1,11 +1,12 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace PuppeteerSharp.Helpers
 {
     internal class MultiMap<TKey, TValue>
     {
-        private readonly Dictionary<TKey, HashSet<TValue>> _map = new Dictionary<TKey, HashSet<TValue>>();
+        private readonly ConcurrentDictionary<TKey, HashSet<TValue>> _map = new ConcurrentDictionary<TKey, HashSet<TValue>>();
 
         internal void Add(TKey key, TValue value)
         {
@@ -16,7 +17,7 @@ namespace PuppeteerSharp.Helpers
             else
             {
                 set = new HashSet<TValue> { value };
-                _map.Add(key, set);
+                _map.TryAdd(key, set);
             }
         }
 
@@ -30,6 +31,6 @@ namespace PuppeteerSharp.Helpers
             => _map.TryGetValue(key, out var set) && set.Remove(value);
 
         internal TValue FirstValue(TKey key)
-            => _map.TryGetValue(key, out var set) ? set.FirstOrDefault() : default(TValue);
+            => _map.TryGetValue(key, out var set) ? set.FirstOrDefault() : default;
     }
 }

--- a/lib/PuppeteerSharp/NetworkManager.cs
+++ b/lib/PuppeteerSharp/NetworkManager.cs
@@ -268,22 +268,28 @@ namespace PuppeteerSharp
                     redirectChain = request.RedirectChainList;
                 }
             }
-            Frame frame = null;
-            FrameManager?.Frames.TryGetValue(e.FrameId, out frame);
-
-            request = new Request(
-                _client,
-                frame,
-                interceptionId,
-                _userRequestInterceptionEnabled,
-                e,
-                redirectChain);
-
-            _requestIdToRequest.Add(e.RequestId, request);
-            Request(this, new RequestEventArgs
+            if (!_requestIdToRequest.TryGetValue(e.RequestId, out var currentRequest) ||
+              currentRequest.Frame == null)
             {
-                Request = request
-            });
+                Frame frame = null;
+                FrameManager?.Frames.TryGetValue(e.FrameId, out frame);
+
+                request = new Request(
+                    _client,
+                    frame,
+                    interceptionId,
+                    _userRequestInterceptionEnabled,
+                    e,
+                    redirectChain);
+
+
+                _requestIdToRequest[e.RequestId] = request;
+
+                Request(this, new RequestEventArgs
+                {
+                    Request = request
+                });
+            }
         }
 
         private void OnRequestServedFromCache(RequestServedFromCacheResponse response)

--- a/lib/PuppeteerSharp/NetworkManager.cs
+++ b/lib/PuppeteerSharp/NetworkManager.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -12,9 +13,9 @@ namespace PuppeteerSharp
         #region Private members
 
         private readonly CDPSession _client;
-        private readonly Dictionary<string, Request> _requestIdToRequest = new Dictionary<string, Request>();
-        private readonly Dictionary<string, RequestWillBeSentPayload> _requestIdToRequestWillBeSentEvent =
-            new Dictionary<string, RequestWillBeSentPayload>();
+        private readonly IDictionary<string, Request> _requestIdToRequest = new ConcurrentDictionary<string, Request>();
+        private readonly IDictionary<string, RequestWillBeSentPayload> _requestIdToRequestWillBeSentEvent =
+            new ConcurrentDictionary<string, RequestWillBeSentPayload>();
         private readonly MultiMap<string, string> _requestHashToRequestIds = new MultiMap<string, string>();
         private readonly MultiMap<string, string> _requestHashToInterceptionIds = new MultiMap<string, string>();
         private readonly ILogger _logger;

--- a/lib/PuppeteerSharp/NetworkManager.cs
+++ b/lib/PuppeteerSharp/NetworkManager.cs
@@ -282,7 +282,6 @@ namespace PuppeteerSharp
                     e,
                     redirectChain);
 
-
                 _requestIdToRequest[e.RequestId] = request;
 
                 Request(this, new RequestEventArgs

--- a/lib/PuppeteerSharp/Page.cs
+++ b/lib/PuppeteerSharp/Page.cs
@@ -235,7 +235,7 @@ namespace PuppeteerSharp
         /// Gets all frames attached to the page.
         /// </summary>
         /// <value>An array of all frames attached to the page.</value>
-        public Frame[] Frames => _frameManager.Frames.Values.ToArray();
+        public Frame[] Frames => _frameManager.GetFrames();
 
         /// <summary>
         /// Gets all workers in the page.

--- a/lib/PuppeteerSharp/TargetType.cs
+++ b/lib/PuppeteerSharp/TargetType.cs
@@ -35,11 +35,15 @@ namespace PuppeteerSharp
         /// </summary>
         [EnumMember(Value = "background_page")]
         BackgroundPage,
-
         /// <summary>
         /// Target type worker.
         /// </summary>
         [EnumMember(Value = "worker")]
         Worker,
+        /// <summary>
+        /// Target type javascript.
+        /// </summary>
+        [EnumMember(Value = "javascript")]
+        Javascript
     }
 }


### PR DESCRIPTION
* Now the Frames Dictionary is a ConcurrentDictionary. That made several tests to fail because the order of the items in the ConcurrentDictionary is not guaranteed. I had to code some helper methods on the tests, such as `FirstChildFrame();` to help us find test frames.
 * Many Dictionaries were changed to ConcurrentDictionary.
 * In some scenarios (a.k.a. #717) async events caused messages coming to be processed before the Frame was created. That's why, where we were doing things like 

```cs
_frameManager.Frames[nodeInfo.Node.FrameId]
``` 

I replaced it to 

```cs
await _frameManager.GetFrameAsync(nodeInfo.Node.FrameId);
``` 

In order to get a Task if the Frame has not been created yet.

closes #717