### PR TITLE
Improve internal exception handling

### DIFF
--- a/lib/PuppeteerSharp.Tests/BrowserTests/Events/DisconnectedTests.cs
+++ b/lib/PuppeteerSharp.Tests/BrowserTests/Events/DisconnectedTests.cs
@@ -90,6 +90,7 @@ namespace PuppeteerSharp.Tests.BrowserTests.Events
                 //Whether from the Connection rejecting a message from the CDPSession 
                 //or from the CDPSession trying to send a message to a closed connection
                 Assert.IsType<TargetClosedException>(exception.InnerException);
+                Assert.Equal("Connection disposed", ((TargetClosedException)exception.InnerException).CloseReason);
             }
         }
     }

--- a/lib/PuppeteerSharp.Tests/PageTests/CloseTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/CloseTests.cs
@@ -13,13 +13,12 @@ namespace PuppeteerSharp.Tests.PageTests
         public async Task ShouldRejectAllPromisesWhenPageIsClosed()
         {
             var neverResolves = Page.EvaluateFunctionAsync("() => new Promise(r => {})");
-
-            // Put into a var to avoid warning
-            var t = Page.CloseAsync();
+            _ = Page.CloseAsync();
 
             var exception = await Assert.ThrowsAsync<EvaluationFailedException>(async () => await neverResolves);
             Assert.IsType<TargetClosedException>(exception.InnerException);
             Assert.Contains("Protocol error", exception.Message);
+            Assert.Equal("Target.detachedFromTarget", ((TargetClosedException)exception.InnerException).CloseReason);
         }
 
         [Fact]

--- a/lib/PuppeteerSharp/Browser.cs
+++ b/lib/PuppeteerSharp/Browser.cs
@@ -330,19 +330,28 @@ namespace PuppeteerSharp
 
         private async void Connect_MessageReceived(object sender, MessageEventArgs e)
         {
-            switch (e.MessageID)
+            try
             {
-                case "Target.targetCreated":
-                    await CreateTargetAsync(e.MessageData.ToObject<TargetCreatedResponse>()).ConfigureAwait(false);
-                    return;
+                switch (e.MessageID)
+                {
+                    case "Target.targetCreated":
+                        await CreateTargetAsync(e.MessageData.ToObject<TargetCreatedResponse>()).ConfigureAwait(false);
+                        return;
 
-                case "Target.targetDestroyed":
-                    await DestroyTargetAsync(e.MessageData.ToObject<TargetDestroyedResponse>()).ConfigureAwait(false);
-                    return;
+                    case "Target.targetDestroyed":
+                        await DestroyTargetAsync(e.MessageData.ToObject<TargetDestroyedResponse>()).ConfigureAwait(false);
+                        return;
 
-                case "Target.targetInfoChanged":
-                    ChangeTargetInfo(e.MessageData.ToObject<TargetCreatedResponse>());
-                    return;
+                    case "Target.targetInfoChanged":
+                        ChangeTargetInfo(e.MessageData.ToObject<TargetCreatedResponse>());
+                        return;
+                }
+            }
+            catch (Exception ex)
+            {
+                var message = $"Browser failed to process {e.MessageID}. {ex.Message}. {ex.StackTrace}";
+                _logger.LogError(ex, message);
+                Connection.Close(message);
             }
         }
 

--- a/lib/PuppeteerSharp/Connection.cs
+++ b/lib/PuppeteerSharp/Connection.cs
@@ -75,6 +75,11 @@ namespace PuppeteerSharp
         public bool IsClosed { get; internal set; }
 
         /// <summary>
+        /// Connection close reason.
+        /// </summary>
+        public string CloseReason { get; private set; }
+
+        /// <summary>
         /// Gets the logger factory.
         /// </summary>
         /// <value>The logger factory.</value>
@@ -88,7 +93,7 @@ namespace PuppeteerSharp
         {
             if (IsClosed)
             {
-                throw new TargetClosedException($"Protocol error({method}): Target closed.");
+                throw new TargetClosedException($"Protocol error({method}): Target closed.", CloseReason);
             }
 
             var id = Interlocked.Increment(ref _lastId);
@@ -137,27 +142,29 @@ namespace PuppeteerSharp
         internal bool HasPendingCallbacks() => _callbacks.Count != 0;
         #endregion
 
-        private void OnClose()
+        internal void Close(string closeReason)
         {
             if (IsClosed)
             {
                 return;
             }
             IsClosed = true;
+            CloseReason = closeReason;
 
             Transport.StopReading();
             Closed?.Invoke(this, new EventArgs());
 
             foreach (var session in _sessions.Values.ToArray())
             {
-                session.OnClosed();
+                session.Close(closeReason);
             }
             _sessions.Clear();
 
             foreach (var response in _callbacks.Values.ToArray())
             {
                 response.TaskWrapper.TrySetException(new TargetClosedException(
-                    $"Protocol error({response.Method}): Target closed."
+                    $"Protocol error({response.Method}): Target closed.",
+                    closeReason
                 ));
             }
             _callbacks.Clear();
@@ -176,77 +183,86 @@ namespace PuppeteerSharp
 
         private async void Transport_MessageReceived(object sender, MessageReceivedEventArgs e)
         {
-            var response = e.Message;
-            JObject obj = null;
-
-            if (response.Length > 0 && Delay > 0)
-            {
-                await Task.Delay(Delay).ConfigureAwait(false);
-            }
-
             try
             {
-                obj = JObject.Parse(response);
-            }
-            catch (JsonException exc)
-            {
-                _logger.LogError(exc, "Failed to deserialize response", response);
-                return;
-            }
+                var response = e.Message;
+                JObject obj = null;
 
-            _logger.LogTrace("◀ Receive {Message}", response);
-
-            var id = obj[MessageKeys.Id]?.Value<int>();
-
-            if (id.HasValue)
-            {
-                //If we get the object we are waiting for we return if
-                //if not we add this to the list, sooner or later some one will come for it 
-                if (_callbacks.TryRemove(id.Value, out var callback))
+                if (response.Length > 0 && Delay > 0)
                 {
-                    if (obj[MessageKeys.Error] != null)
-                    {
-                        callback.TaskWrapper.TrySetException(new MessageException(callback, obj));
-                    }
-                    else
-                    {
-                        callback.TaskWrapper.TrySetResult(obj[MessageKeys.Result].Value<JObject>());
-                    }
+                    await Task.Delay(Delay).ConfigureAwait(false);
                 }
-            }
-            else
-            {
-                var method = obj[MessageKeys.Method].AsString();
-                var param = obj[MessageKeys.Params];
 
-                if (method == "Target.receivedMessageFromTarget")
+                try
                 {
-                    var sessionId = param[MessageKeys.SessionId].AsString();
-                    if (_sessions.TryGetValue(sessionId, out var session))
-                    {
-                        session.OnMessage(param[MessageKeys.Message].AsString());
-                    }
+                    obj = JObject.Parse(response);
                 }
-                else if (method == "Target.detachedFromTarget")
+                catch (JsonException exc)
                 {
-                    var sessionId = param[MessageKeys.SessionId].AsString();
-                    if (_sessions.TryRemove(sessionId, out var session) && !session.IsClosed)
+                    _logger.LogError(exc, "Failed to deserialize response", response);
+                    return;
+                }
+
+                _logger.LogTrace("◀ Receive {Message}", response);
+
+                var id = obj[MessageKeys.Id]?.Value<int>();
+
+                if (id.HasValue)
+                {
+                    //If we get the object we are waiting for we return if
+                    //if not we add this to the list, sooner or later some one will come for it 
+                    if (_callbacks.TryRemove(id.Value, out var callback))
                     {
-                        session.OnClosed();
+                        if (obj[MessageKeys.Error] != null)
+                        {
+                            callback.TaskWrapper.TrySetException(new MessageException(callback, obj));
+                        }
+                        else
+                        {
+                            callback.TaskWrapper.TrySetResult(obj[MessageKeys.Result].Value<JObject>());
+                        }
                     }
                 }
                 else
                 {
-                    MessageReceived?.Invoke(this, new MessageEventArgs
+                    var method = obj[MessageKeys.Method].AsString();
+                    var param = obj[MessageKeys.Params];
+
+                    if (method == "Target.receivedMessageFromTarget")
                     {
-                        MessageID = method,
-                        MessageData = param
-                    });
+                        var sessionId = param[MessageKeys.SessionId].AsString();
+                        if (_sessions.TryGetValue(sessionId, out var session))
+                        {
+                            session.OnMessage(param[MessageKeys.Message].AsString());
+                        }
+                    }
+                    else if (method == "Target.detachedFromTarget")
+                    {
+                        var sessionId = param[MessageKeys.SessionId].AsString();
+                        if (_sessions.TryRemove(sessionId, out var session) && !session.IsClosed)
+                        {
+                            session.Close("Target.detachedFromTarget");
+                        }
+                    }
+                    else
+                    {
+                        MessageReceived?.Invoke(this, new MessageEventArgs
+                        {
+                            MessageID = method,
+                            MessageData = param
+                        });
+                    }
                 }
+            }
+            catch (Exception ex)
+            {
+                var message = $"Connection failed to process {e.Message}. {ex.Message}. {ex.StackTrace}";
+                _logger.LogError(ex, message);
+                Close(message);
             }
         }
 
-        void Transport_Closed(object sender, EventArgs e) => OnClose();
+        void Transport_Closed(object sender, TransportClosedEventArgs e) => Close(e.CloseReason);
 
         #endregion
 
@@ -290,7 +306,7 @@ namespace PuppeteerSharp
         /// <see cref="Connection"/> was occupying.</remarks>
         public void Dispose()
         {
-            OnClose();
+            Close("Connection disposed");
             Transport.Dispose();
         }
         #endregion
@@ -301,6 +317,7 @@ namespace PuppeteerSharp
         Task<JObject> IConnection.SendAsync(string method, dynamic args, bool waitForCallback)
             => SendAsync(method, args, waitForCallback);
         IConnection IConnection.Connection => null;
+        void IConnection.Close(string closeReason) => Close(closeReason);
         #endregion
     }
 }

--- a/lib/PuppeteerSharp/IConnection.cs
+++ b/lib/PuppeteerSharp/IConnection.cs
@@ -21,6 +21,10 @@ namespace PuppeteerSharp
         /// <value><c>true</c> if is closed; otherwise, <c>false</c>.</value>
         bool IsClosed { get; }
         /// <summary>
+        /// Connection close reason.
+        /// </summary>
+        string CloseReason { get; }
+        /// <summary>
         /// Sends a message to chromium.
         /// </summary>
         /// <returns>The async.</returns>
@@ -39,5 +43,10 @@ namespace PuppeteerSharp
         /// Occurs when the connection is closed.
         /// </summary>
         event EventHandler Closed;
+        /// <summary>
+        /// Close the connection.
+        /// </summary>
+        /// <param name="closeReason">Close reason.</param>
+        void Close(string closeReason);
     }
 }

--- a/lib/PuppeteerSharp/NavigatorWatcher.cs
+++ b/lib/PuppeteerSharp/NavigatorWatcher.cs
@@ -63,8 +63,9 @@ namespace PuppeteerSharp
             frameManager.FrameNavigatedWithinDocument += NavigatedWithinDocument;
             frameManager.FrameDetached += OnFrameDetached;
             networkManager.Request += OnRequest;
-            Connection.FromSession(client).Closed += (sender, e)
-                => Terminate(new TargetClosedException("Navigation failed because browser has disconnected!"));
+            var connection = Connection.FromSession(client);
+            connection.Closed += (sender, e)
+                => Terminate(new TargetClosedException("Navigation failed because browser has disconnected!", connection.CloseReason));
 
             _sameDocumentNavigationTaskWrapper = new TaskCompletionSource<bool>();
             _newDocumentNavigationTaskWrapper = new TaskCompletionSource<bool>();

--- a/lib/PuppeteerSharp/NetworkManager.cs
+++ b/lib/PuppeteerSharp/NetworkManager.cs
@@ -101,26 +101,35 @@ namespace PuppeteerSharp
 
         private async void Client_MessageReceived(object sender, MessageEventArgs e)
         {
-            switch (e.MessageID)
+            try
             {
-                case "Network.requestWillBeSent":
-                    await OnRequestWillBeSentAsync(e.MessageData.ToObject<RequestWillBeSentPayload>());
-                    break;
-                case "Network.requestIntercepted":
-                    await OnRequestInterceptedAsync(e.MessageData.ToObject<RequestInterceptedResponse>()).ConfigureAwait(false);
-                    break;
-                case "Network.requestServedFromCache":
-                    OnRequestServedFromCache(e.MessageData.ToObject<RequestServedFromCacheResponse>());
-                    break;
-                case "Network.responseReceived":
-                    OnResponseReceived(e.MessageData.ToObject<ResponseReceivedResponse>());
-                    break;
-                case "Network.loadingFinished":
-                    OnLoadingFinished(e.MessageData.ToObject<LoadingFinishedResponse>());
-                    break;
-                case "Network.loadingFailed":
-                    OnLoadingFailed(e.MessageData.ToObject<LoadingFailedResponse>());
-                    break;
+                switch (e.MessageID)
+                {
+                    case "Network.requestWillBeSent":
+                        await OnRequestWillBeSentAsync(e.MessageData.ToObject<RequestWillBeSentPayload>());
+                        break;
+                    case "Network.requestIntercepted":
+                        await OnRequestInterceptedAsync(e.MessageData.ToObject<RequestInterceptedResponse>()).ConfigureAwait(false);
+                        break;
+                    case "Network.requestServedFromCache":
+                        OnRequestServedFromCache(e.MessageData.ToObject<RequestServedFromCacheResponse>());
+                        break;
+                    case "Network.responseReceived":
+                        OnResponseReceived(e.MessageData.ToObject<ResponseReceivedResponse>());
+                        break;
+                    case "Network.loadingFinished":
+                        OnLoadingFinished(e.MessageData.ToObject<LoadingFinishedResponse>());
+                        break;
+                    case "Network.loadingFailed":
+                        OnLoadingFailed(e.MessageData.ToObject<LoadingFailedResponse>());
+                        break;
+                }
+            }
+            catch (Exception ex)
+            {
+                var message = $"NetworkManager failed to process {e.MessageID}. {ex.Message}. {ex.StackTrace}";
+                _logger.LogError(ex, message);
+                _client.Close(message);
             }
         }
 

--- a/lib/PuppeteerSharp/Page.cs
+++ b/lib/PuppeteerSharp/Page.cs
@@ -1767,44 +1767,53 @@ namespace PuppeteerSharp
 
         private async void Client_MessageReceived(object sender, MessageEventArgs e)
         {
-            switch (e.MessageID)
+            try
             {
-                case "Page.domContentEventFired":
-                    DOMContentLoaded?.Invoke(this, EventArgs.Empty);
-                    break;
-                case "Page.loadEventFired":
-                    Load?.Invoke(this, EventArgs.Empty);
-                    break;
-                case "Runtime.consoleAPICalled":
-                    await OnConsoleAPI(e.MessageData.ToObject<PageConsoleResponse>()).ConfigureAwait(false);
-                    break;
-                case "Page.javascriptDialogOpening":
-                    OnDialog(e.MessageData.ToObject<PageJavascriptDialogOpeningResponse>());
-                    break;
-                case "Runtime.exceptionThrown":
-                    HandleException(e.MessageData.SelectToken(MessageKeys.ExceptionDetails).ToObject<EvaluateExceptionDetails>());
-                    break;
-                case "Security.certificateError":
-                    await OnCertificateError(e.MessageData.ToObject<CertificateErrorResponse>()).ConfigureAwait(false);
-                    break;
-                case "Inspector.targetCrashed":
-                    OnTargetCrashed();
-                    break;
-                case "Performance.metrics":
-                    EmitMetrics(e.MessageData.ToObject<PerformanceMetricsResponse>());
-                    break;
-                case "Target.attachedToTarget":
-                    await OnAttachedToTarget(e).ConfigureAwait(false);
-                    break;
-                case "Target.detachedFromTarget":
-                    OnDetachedFromTarget(e);
-                    break;
-                case "Log.entryAdded":
-                    OnLogEntryAdded(e.MessageData.ToObject<LogEntryAddedResponse>());
-                    break;
-                case "Runtime.bindingCalled":
-                    await OnBindingCalled(e.MessageData.ToObject<BindingCalledResponse>()).ConfigureAwait(false);
-                    break;
+                switch (e.MessageID)
+                {
+                    case "Page.domContentEventFired":
+                        DOMContentLoaded?.Invoke(this, EventArgs.Empty);
+                        break;
+                    case "Page.loadEventFired":
+                        Load?.Invoke(this, EventArgs.Empty);
+                        break;
+                    case "Runtime.consoleAPICalled":
+                        await OnConsoleAPI(e.MessageData.ToObject<PageConsoleResponse>()).ConfigureAwait(false);
+                        break;
+                    case "Page.javascriptDialogOpening":
+                        OnDialog(e.MessageData.ToObject<PageJavascriptDialogOpeningResponse>());
+                        break;
+                    case "Runtime.exceptionThrown":
+                        HandleException(e.MessageData.SelectToken(MessageKeys.ExceptionDetails).ToObject<EvaluateExceptionDetails>());
+                        break;
+                    case "Security.certificateError":
+                        await OnCertificateError(e.MessageData.ToObject<CertificateErrorResponse>()).ConfigureAwait(false);
+                        break;
+                    case "Inspector.targetCrashed":
+                        OnTargetCrashed();
+                        break;
+                    case "Performance.metrics":
+                        EmitMetrics(e.MessageData.ToObject<PerformanceMetricsResponse>());
+                        break;
+                    case "Target.attachedToTarget":
+                        await OnAttachedToTarget(e).ConfigureAwait(false);
+                        break;
+                    case "Target.detachedFromTarget":
+                        OnDetachedFromTarget(e);
+                        break;
+                    case "Log.entryAdded":
+                        OnLogEntryAdded(e.MessageData.ToObject<LogEntryAddedResponse>());
+                        break;
+                    case "Runtime.bindingCalled":
+                        await OnBindingCalled(e.MessageData.ToObject<BindingCalledResponse>()).ConfigureAwait(false);
+                        break;
+                }
+            }
+            catch (Exception ex)
+            {
+                var message = $"Page failed to process {e.MessageID}. {ex.Message}. {ex.StackTrace}";
+                _logger.LogError(ex, message);
+                Client.Close(message);
             }
         }
 

--- a/lib/PuppeteerSharp/PageCoverage/CSSCoverage.cs
+++ b/lib/PuppeteerSharp/PageCoverage/CSSCoverage.cs
@@ -40,7 +40,7 @@ namespace PuppeteerSharp.PageCoverage
             _stylesheetURLs.Clear();
             _stylesheetSources.Clear();
 
-            _client.MessageReceived += client_MessageReceived;
+            _client.MessageReceived += Client_MessageReceived;
 
             return Task.WhenAll(
                 _client.SendAsync("DOM.enable"),
@@ -63,7 +63,7 @@ namespace PuppeteerSharp.PageCoverage
                 _client.SendAsync("CSS.disable"),
                 _client.SendAsync("DOM.disable")
             ).ConfigureAwait(false);
-            _client.MessageReceived -= client_MessageReceived;
+            _client.MessageReceived -= Client_MessageReceived;
 
             var styleSheetIdToCoverage = new Dictionary<string, List<CoverageResponseRange>>();
             foreach (var entry in ruleTrackingResponseTask.Result.RuleUsage)
@@ -99,16 +99,25 @@ namespace PuppeteerSharp.PageCoverage
             return coverage.ToArray();
         }
 
-        private async void client_MessageReceived(object sender, MessageEventArgs e)
+        private async void Client_MessageReceived(object sender, MessageEventArgs e)
         {
-            switch (e.MessageID)
+            try
             {
-                case "CSS.styleSheetAdded":
-                    await OnStyleSheetAdded(e.MessageData.ToObject<CSSStyleSheetAddedResponse>()).ConfigureAwait(false);
-                    break;
-                case "Runtime.executionContextsCleared":
-                    OnExecutionContextsCleared();
-                    break;
+                switch (e.MessageID)
+                {
+                    case "CSS.styleSheetAdded":
+                        await OnStyleSheetAdded(e.MessageData.ToObject<CSSStyleSheetAddedResponse>()).ConfigureAwait(false);
+                        break;
+                    case "Runtime.executionContextsCleared":
+                        OnExecutionContextsCleared();
+                        break;
+                }
+            }
+            catch (Exception ex)
+            {
+                var message = $"CSSCoverage failed to process {e.MessageID}. {ex.Message}. {ex.StackTrace}";
+                _logger.LogError(ex, message);
+                _client.Close(message);
             }
         }
 

--- a/lib/PuppeteerSharp/TargetClosedException.cs
+++ b/lib/PuppeteerSharp/TargetClosedException.cs
@@ -6,11 +6,16 @@
     public class TargetClosedException : PuppeteerException
     {
         /// <summary>
+        /// Close Reason.
+        /// </summary>
+        /// <value>The close reason.</value>
+        public string CloseReason { get; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="TargetClosedException"/> class.
         /// </summary>
         /// <param name="message">Message.</param>
-        public TargetClosedException(string message) : base(message)
-        {
-        }
+        /// <param name="closeReason">Close reason.</param>
+        public TargetClosedException(string message, string closeReason) : base(message) => CloseReason = closeReason;
     }
 }

--- a/lib/PuppeteerSharp/Tracing.cs
+++ b/lib/PuppeteerSharp/Tracing.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using PuppeteerSharp.Messaging;
 
 namespace PuppeteerSharp
@@ -40,10 +41,12 @@ namespace PuppeteerSharp
             "disabled-by-default-devtools.timeline.stack",
             "disabled-by-default-v8.cpu_profiler"
         };
+        private readonly ILogger _logger;
 
         internal Tracing(CDPSession client)
         {
             _client = client;
+            _logger = client.LoggerFactory.CreateLogger<Tracing>();
         }
 
         /// <summary>
@@ -85,9 +88,18 @@ namespace PuppeteerSharp
 
             async void EventHandler(object sender, TracingCompleteEventArgs e)
             {
-                var tracingData = await ReadStream(e.Stream, _path).ConfigureAwait(false);
-                _client.TracingComplete -= EventHandler;
-                taskWrapper.SetResult(tracingData);
+                try
+                {
+                    var tracingData = await ReadStream(e.Stream, _path).ConfigureAwait(false);
+                    _client.TracingComplete -= EventHandler;
+                    taskWrapper.SetResult(tracingData);
+                }
+                catch (Exception ex)
+                {
+                    var message = $"Tracing failed to process the tracing complete. {ex.Message}. {ex.StackTrace}";
+                    _logger.LogError(ex, message);
+                    _client.Close(message);
+                }
             }
 
             _client.TracingComplete += EventHandler;

--- a/lib/PuppeteerSharp/Transport/IConnectionTransport.cs
+++ b/lib/PuppeteerSharp/Transport/IConnectionTransport.cs
@@ -26,7 +26,7 @@ namespace PuppeteerSharp.Transport
         /// <summary>
         /// Occurs when the transport is closed.
         /// </summary>
-        event EventHandler Closed;
+        event EventHandler<TransportClosedEventArgs> Closed;
         /// <summary>
         /// Occurs when a message is received.
         /// </summary>

--- a/lib/PuppeteerSharp/Transport/TransportClosedEventArgs.cs
+++ b/lib/PuppeteerSharp/Transport/TransportClosedEventArgs.cs
@@ -1,0 +1,19 @@
+﻿using System;
+namespace PuppeteerSharp.Transport
+{
+    /// <summary>
+    /// <see cref="IConnectionTransport.Closed"/>
+    /// </summary>
+    public class TransportClosedEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Gets or sets the close reason.
+        /// </summary>
+        public string CloseReason { get; set; }
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PuppeteerSharp.Transport.TransportClosedEventArgs"/> class.
+        /// </summary>
+        /// <param name="closeReason">Close reason.</param>
+        public TransportClosedEventArgs(string closeReason) => CloseReason = closeReason;
+    }
+}

--- a/lib/PuppeteerSharp/Transport/WebSocketTransport.cs
+++ b/lib/PuppeteerSharp/Transport/WebSocketTransport.cs
@@ -24,7 +24,7 @@ namespace PuppeteerSharp.Transport
         /// <summary>
         /// Occurs when the transport is closed.
         /// </summary>
-        public event EventHandler Closed;
+        public event EventHandler<TransportClosedEventArgs> Closed;
         /// <summary>
         /// Occurs when a message is received.
         /// </summary>
@@ -77,7 +77,7 @@ namespace PuppeteerSharp.Transport
             {
                 if (IsClosed)
                 {
-                    OnClose();
+                    OnClose("WebSocket is closed");
                     return null;
                 }
 
@@ -97,9 +97,9 @@ namespace PuppeteerSharp.Transport
                     {
                         return null;
                     }
-                    catch (Exception)
+                    catch (Exception ex)
                     {
-                        OnClose();
+                        OnClose(ex.Message);
                         return null;
                     }
 
@@ -111,7 +111,7 @@ namespace PuppeteerSharp.Transport
                     }
                     else if (result.MessageType == WebSocketMessageType.Close)
                     {
-                        OnClose();
+                        OnClose("WebSocket closed");
                         return null;
                     }
                 }
@@ -120,9 +120,9 @@ namespace PuppeteerSharp.Transport
             }
         }
 
-        private void OnClose()
+        private void OnClose(string closeReason)
         {
-            Closed?.Invoke(this, EventArgs.Empty);
+            Closed?.Invoke(this, new TransportClosedEventArgs(closeReason));
             IsClosed = true;
         }
 

--- a/lib/PuppeteerSharp/Worker.cs
+++ b/lib/PuppeteerSharp/Worker.cs
@@ -98,17 +98,26 @@ namespace PuppeteerSharp
 
         internal async void OnMessageReceived(object sender, MessageEventArgs e)
         {
-            switch (e.MessageID)
+            try
             {
-                case "Runtime.executionContextCreated":
-                    OnExecutionContextCreated(e);
-                    break;
-                case "Runtime.consoleAPICalled":
-                    await OnConsoleAPICalled(e).ConfigureAwait(false);
-                    break;
-                case "Runtime.exceptionThrown":
-                    OnExceptionThrown(e);
-                    break;
+                switch (e.MessageID)
+                {
+                    case "Runtime.executionContextCreated":
+                        OnExecutionContextCreated(e);
+                        break;
+                    case "Runtime.consoleAPICalled":
+                        await OnConsoleAPICalled(e).ConfigureAwait(false);
+                        break;
+                    case "Runtime.exceptionThrown":
+                        OnExceptionThrown(e);
+                        break;
+                }
+            }
+            catch (Exception ex)
+            {
+                var message = $"Worker failed to process {e.MessageID}. {ex.Message}. {ex.StackTrace}";
+                _logger.LogError(ex, message);
+                _client.Close(message);
             }
         }
 


### PR DESCRIPTION
If we fail to process a message coming from chromium we can't just fail trusting that the user will catch that exception, because that call won't not part of the call stack coming from the user but from the WebSocket listener. This was causing the [unrecoverable exceptions](https://github.com/kblok/puppeteer-sharp/issues/717).

In order to fix this, we are going to close the `IConnection` (`CDPSession` or `Connection`) if we fail to process a message. We will add that exception as a `CloseReason` to the `IConnection` and also to the `TargetClosedException` in order to help us and the user to have more information about the problem we might have.

closes #752