### PR TITLE
CloseAsync should wait for the target to be closed

### DIFF
--- a/lib/PuppeteerSharp/Page.cs
+++ b/lib/PuppeteerSharp/Page.cs
@@ -1058,7 +1058,7 @@ namespace PuppeteerSharp
             }
 
             _logger.LogWarning("Protocol error: Connection closed. Most likely the page has been closed.");
-            return Task.CompletedTask;
+            return Target.CloseTask;
         }
 
         /// <summary>


### PR DESCRIPTION
This would fix this error we get some times https://ci.appveyor.com/project/kblok/puppeteer-sharp/builds/21196351/job/g0o4p4hvl5e04grn#L273