### PR TITLE
Improve race conditions on ShouldReturnMatchingResponses

### DIFF
--- a/lib/PuppeteerSharp.Tests/FrameTests/GoToTests.cs
+++ b/lib/PuppeteerSharp.Tests/FrameTests/GoToTests.cs
@@ -47,39 +47,50 @@ namespace PuppeteerSharp.Tests.FrameTests
             await Page.SetCacheEnabledAsync(false);
             await Page.GoToAsync(TestConstants.EmptyPage);
             // Attach three frames.
-            var frameTasks = new List<Task<Frame>>
+            var matchingData = new MatchingResponseData[]
             {
-                FrameUtils.AttachFrameAsync(Page, "frame1", TestConstants.EmptyPage),
-                FrameUtils.AttachFrameAsync(Page, "frame2", TestConstants.EmptyPage),
-                FrameUtils.AttachFrameAsync(Page, "frame3", TestConstants.EmptyPage)
+                new MatchingResponseData{ FrameTask =  FrameUtils.AttachFrameAsync(Page, "frame1", TestConstants.EmptyPage)},
+                new MatchingResponseData{ FrameTask =  FrameUtils.AttachFrameAsync(Page, "frame2", TestConstants.EmptyPage)},
+                new MatchingResponseData{ FrameTask =  FrameUtils.AttachFrameAsync(Page, "frame3", TestConstants.EmptyPage)}
             };
-            await Task.WhenAll(frameTasks);
+
+            await Task.WhenAll(matchingData.Select(m => m.FrameTask));
 
             // Navigate all frames to the same URL.
-            var serverResponses = new List<TaskCompletionSource<string>>();
-            Server.SetRoute("/one-style.html", async (context) =>
+            var requestHandler = new RequestDelegate(async (context) =>
             {
-                var tcs = new TaskCompletionSource<string>();
-                serverResponses.Add(tcs);
-                await context.Response.WriteAsync(await tcs.Task);
+                if (int.TryParse(context.Request.Query["index"], out var index))
+                {
+                    await context.Response.WriteAsync(await matchingData[index].ServerResponseTcs.Task);
+                }
             });
 
-            var navigations = new List<Task<Response>>();
+            Server.SetRoute("/one-style.html?index=0", requestHandler);
+            Server.SetRoute("/one-style.html?index=1", requestHandler);
+            Server.SetRoute("/one-style.html?index=2", requestHandler);
+
             for (var i = 0; i < 3; ++i)
             {
-                var waitRequestTask = Server.WaitForRequest("/one-style.html");
-                navigations.Add(frameTasks[i].Result.GoToAsync(TestConstants.ServerUrl + "/one-style.html"));
+                var waitRequestTask = Server.WaitForRequest($"/one-style.html");
+                matchingData[i].NavigationTask = matchingData[i].FrameTask.Result.GoToAsync($"{TestConstants.ServerUrl}/one-style.html?index={i}");
                 await waitRequestTask;
             }
             // Respond from server out-of-order.
             var serverResponseTexts = new string[] { "AAA", "BBB", "CCC" };
             for (var i = 0; i < 3; ++i)
             {
-                serverResponses[i].TrySetResult(serverResponseTexts[i]);
-                var response = await navigations[i];
-                Assert.Same(frameTasks[i].Result, response.Frame);
+                matchingData[i].ServerResponseTcs.TrySetResult(serverResponseTexts[i]);
+                var response = await matchingData[i].NavigationTask;
+                Assert.Same(matchingData[i].FrameTask.Result, response.Frame);
                 Assert.Equal(serverResponseTexts[i], await response.TextAsync());
             }
+        }
+
+        private class MatchingResponseData
+        {
+            public Task<Frame> FrameTask { get; internal set; }
+            public TaskCompletionSource<string> ServerResponseTcs { get; internal set; } = new TaskCompletionSource<string>();
+            public Task<Response> NavigationTask { get; internal set; }
         }
     }
 }


### PR DESCRIPTION
Refactored ShouldReturnMatchingResponses so we guarantee some order in the execution.

This would prevent this random error https://ci.appveyor.com/project/kblok/puppeteer-sharp-esipd/builds/21205234#L255