### PR TITLE
Add timeouts to ShouldWorkWithBothDomcontentloadedAndLoad

### DIFF
--- a/lib/PuppeteerSharp.Tests/PageTests/WaitForNavigationTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/WaitForNavigationTests.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
+using PuppeteerSharp.Helpers;
 
 namespace PuppeteerSharp.Tests.PageTests
 {
@@ -34,6 +35,8 @@ namespace PuppeteerSharp.Tests.PageTests
             {
                 return responseCompleted.Task;
             });
+
+            var waitForRequestTask = Server.WaitForRequest("/one-style.css");
             var navigationTask = Page.GoToAsync(TestConstants.ServerUrl + "/one-style.html");
             var domContentLoadedTask = Page.WaitForNavigationAsync(new NavigationOptions
             {
@@ -50,12 +53,12 @@ namespace PuppeteerSharp.Tests.PageTests
                 }
             }).ContinueWith(_ => bothFired = true);
 
-            await Server.WaitForRequest("/one-style.css");
-            await domContentLoadedTask;
+            await waitForRequestTask.WithTimeout();
+            await domContentLoadedTask.WithTimeout();
             Assert.False(bothFired);
             responseCompleted.SetResult(true);
-            await bothFiredTask;
-            await navigationTask;
+            await bothFiredTask.WithTimeout();
+            await navigationTask.WithTimeout();
         }
 
         [Fact]

--- a/lib/PuppeteerSharp.Tests/WorkerTests/WorkerTests.cs
+++ b/lib/PuppeteerSharp.Tests/WorkerTests/WorkerTests.cs
@@ -30,7 +30,7 @@ namespace PuppeteerSharp.Tests.WorkerTests
             Assert.Equal("worker function result", await worker.EvaluateExpressionAsync<string>("self.workerFunction()"));
 
             await Page.GoToAsync(TestConstants.EmptyPage);
-            await workerDestroyedTcs.Task.WithTimeout(1000);
+            await workerDestroyedTcs.Task.WithTimeout();
             Assert.Empty(Page.Workers);
         }
 

--- a/lib/PuppeteerSharp/Helpers/TaskHelper.cs
+++ b/lib/PuppeteerSharp/Helpers/TaskHelper.cs
@@ -16,6 +16,34 @@ namespace PuppeteerSharp.Helpers
         /// <returns>The task result.</returns>
         /// <param name="task">Task to wait for.</param>
         /// <param name="milliseconds">Milliseconds timeout.</param>
+        public static async Task WithTimeout(this Task task, int milliseconds = 1_000)
+        {
+            var tcs = new TaskCompletionSource<bool>();
+            var cancellationToken = new CancellationTokenSource();
+
+            if (milliseconds > 0)
+            {
+                cancellationToken.CancelAfter(milliseconds);
+            }
+
+            using (cancellationToken.Token.Register(s => ((TaskCompletionSource<bool>)s).TrySetResult(true), tcs))
+            {
+                if (task != await Task.WhenAny(task, tcs.Task))
+                {
+                    throw new TimeoutException($"Timeout Exceeded: {milliseconds}ms exceeded");
+                }
+            }
+
+            await task;
+        }
+
+        //Recipe from https://blogs.msdn.microsoft.com/pfxteam/2012/10/05/how-do-i-cancel-non-cancelable-async-operations/
+        /// <summary>
+        /// Cancels the <paramref name="task"/> after <paramref name="milliseconds"/> milliseconds
+        /// </summary>
+        /// <returns>The task result.</returns>
+        /// <param name="task">Task to wait for.</param>
+        /// <param name="milliseconds">Milliseconds timeout.</param>
         /// <typeparam name="T">Task return type.</typeparam>
         public static async Task<T> WithTimeout<T>(this Task<T> task, int milliseconds)
         {


### PR DESCRIPTION
Maybe moving the WaitForRequest would help us to fix this hang. https://ci.appveyor.com/project/kblok/puppeteer-sharp-esipd/builds/21207144#L254

Otherwise, I added some timeouts so we don't hang.