### PR TITLE
Fix minor typo in XML docs

### DIFF
--- a/lib/PuppeteerSharp/BrowserFetcher.cs
+++ b/lib/PuppeteerSharp/BrowserFetcher.cs
@@ -42,7 +42,7 @@ namespace PuppeteerSharp
             FilePermissions.S_IXOTH;
 
         /// <summary>
-        /// Default chromiumg revision.
+        /// Default Chromium revision.
         /// </summary>
         public const int DefaultRevision = 609904;
 
@@ -51,16 +51,19 @@ namespace PuppeteerSharp
         /// </summary>
         /// <value>The downloads folder.</value>
         public string DownloadsFolder { get; }
+        
         /// <summary>
         /// A download host to be used. Defaults to https://storage.googleapis.com.
         /// </summary>
         /// <value>The download host.</value>
         public string DownloadHost { get; }
+        
         /// <summary>
         /// Gets the platform.
         /// </summary>
         /// <value>The platform.</value>
         public Platform Platform { get; }
+        
         /// <summary>
         /// Occurs when download progress in <see cref="DownloadAsync(int)"/> changes.
         /// </summary>


### PR DESCRIPTION
Fixes a minor typo along with a few white-lines for readability.