### PR TITLE
Set headless option to false when Devtools are enabled

### DIFF
--- a/lib/PuppeteerSharp.Tests/LaunchOptionsTests.cs
+++ b/lib/PuppeteerSharp.Tests/LaunchOptionsTests.cs
@@ -1,0 +1,21 @@
+﻿using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace PuppeteerSharp.Tests
+{
+    public class LaunchOptionsTests
+    {
+        [Fact]
+        public void DisableHeadlessWhenDevtoolsEnabled() 
+        {
+            var options = new LaunchOptions
+            {
+                Devtools = true
+            };
+
+            Assert.True(options.Devtools);
+            Assert.False(options.Headless);
+        }
+    }
+}

--- a/lib/PuppeteerSharp/LaunchOptions.cs
+++ b/lib/PuppeteerSharp/LaunchOptions.cs
@@ -13,6 +13,7 @@ namespace PuppeteerSharp
     public class LaunchOptions : IBrowserOptions, IConnectionOptions
     {
         private string[] _ignoredDefaultArgs;
+        private bool _devtools;
 
         /// <summary>
         /// Whether to ignore HTTPS errors during navigation. Defaults to false.
@@ -62,7 +63,18 @@ namespace PuppeteerSharp
         /// <summary>
         /// Whether to auto-open DevTools panel for each tab. If this option is true, the headless option will be set false.
         /// </summary>
-        public bool Devtools { get; set; }
+        public bool Devtools
+        {
+            get => _devtools;
+            set
+            {
+                _devtools = value;
+                if (value)
+                {
+                    Headless = false;
+                }
+            }
+        }
 
         /// <summary>
         /// Keep alive value.


### PR DESCRIPTION
The comments say `the headless option will be set false`:

https://github.com/kblok/puppeteer-sharp/blob/82ab1e0807e9a6ce1f5480379190f87a07819754/lib/PuppeteerSharp/LaunchOptions.cs#L62-L65

However, the headless option was not actually set to `false`.