### PR TITLE
Fix Race conditions on Page.CloseAsync

### DIFF
--- a/lib/PuppeteerSharp/Page.cs
+++ b/lib/PuppeteerSharp/Page.cs
@@ -46,6 +46,7 @@ namespace PuppeteerSharp
         private PageGetLayoutMetricsResponse _burstModeMetrics;
         private bool _screenshotBurstModeOn;
         private ScreenshotOptions _screenshotBurstModeOptions;
+        private TaskCompletionSource<bool> _closeCompletedTcs = new TaskCompletionSource<bool>();
 
         private static readonly Dictionary<string, decimal> _unitToPixels = new Dictionary<string, decimal> {
             {"px", 1},
@@ -80,6 +81,7 @@ namespace PuppeteerSharp
             {
                 Close?.Invoke(this, EventArgs.Empty);
                 IsClosed = true;
+                _closeCompletedTcs.TrySetResult(true);
             });
 
             Client.MessageReceived += Client_MessageReceived;
@@ -1057,7 +1059,7 @@ namespace PuppeteerSharp
             }
 
             _logger.LogWarning("Protocol error: Connection closed. Most likely the page has been closed.");
-            return Target.CloseTask;
+            return _closeCompletedTcs.Task;
         }
 
         /// <summary>


### PR DESCRIPTION
`Target.CloseTask` was being being completed before we set `IsClosed = true;`

It will help us with this race https://ci.appveyor.com/project/kblok/puppeteer-sharp/builds/21332785/job/5wrbvkgq0a351en0#L230 