### PR TITLE
Add overloads of EvaluateFunctionAsync with disposeHandle flag

### DIFF
--- a/lib/PuppeteerSharp.Tests/PageTests/EvalManyTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/EvalManyTests.cs
@@ -27,5 +27,27 @@ namespace PuppeteerSharp.Tests.PageTests
             var divsCount = await divs.EvaluateFunctionAsync<int>("divs => divs.length");
             Assert.Equal(3, divsCount);
         }
+
+        [Fact]
+        public async Task ShouldNotDisposeArrayIfTheDisposeHandleFlagIsSetToFalse()
+        {
+            await Page.SetContentAsync("<div>hello</div><div>beautiful</div><div>world!</div>");
+            var divs = await Page.QuerySelectorAllHandleAsync("div");
+            var divsCount = await divs.EvaluateFunctionAsync<int>("divs => divs.length", disposeHandle: false);
+            var text = await divs.EvaluateFunctionAsync<string>("divs => divs.map(x => x.textContent).join(' ')", disposeHandle: false);
+            await divs.DisposeAsync();
+            Assert.Equal(3, divsCount);
+            Assert.Equal("hello beautiful world!", text);
+        }
+
+        [Fact]
+        public async Task ShouldDisposeArrayIfTheDisposeHandleFlagIsSetToTrue()
+        {
+            await Page.SetContentAsync("<div>hello</div><div>beautiful</div><div>world!</div>");
+            var divs = await Page.QuerySelectorAllHandleAsync("div");
+            await divs.EvaluateFunctionAsync<int>("divs => divs.length", disposeHandle: true);
+            await Assert.ThrowsAsync<MessageException>(()
+                => divs.EvaluateFunctionAsync<string>("divs => divs.map(x => x.textContent).join(' ')"));
+        }
     }
 }

--- a/lib/PuppeteerSharp.Tests/PageTests/EvalTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/EvalTests.cs
@@ -52,5 +52,28 @@ namespace PuppeteerSharp.Tests.PageTests
                 => Page.QuerySelectorAsync("section").EvaluateFunctionAsync<string>("e => e.id"));
             Assert.Contains("failed to find element matching selector", exception.Message);
         }
+
+        [Fact]
+        public async Task ShouldNotDisposeElementIfTheDisposeHandleFlagIsSetToFalse()
+        {
+            await Page.SetContentAsync("<section id='testAttribute'>43543</section>");
+            var section = await Page.QuerySelectorAsync("section");
+            var idAttribute = await section.EvaluateFunctionAsync<string>("e => e.id", disposeHandle: false);
+            var text = await section.EvaluateFunctionAsync<string>("e => e.textContent", disposeHandle: false);
+            await section.DisposeAsync();
+            Assert.Equal("testAttribute", idAttribute);
+            Assert.Equal("43543", text);
+        }
+
+        [Fact]
+        public async Task ShouldDisposeElementIfTheDisposeHandleFlagIsSetToTrue()
+        {
+            await Page.SetContentAsync("<section id='testAttribute'>43543</section>");
+            var section = await Page.QuerySelectorAsync("section");
+            await section.EvaluateFunctionAsync<string>("e => e.id", disposeHandle: true);
+            var exception = await Assert.ThrowsAsync<EvaluationFailedException>(()
+                => section.EvaluateFunctionAsync<string>("e => e.textContent"));
+            Assert.Equal("JSHandle is disposed!", exception.Message);
+        }
     }
 }

--- a/lib/PuppeteerSharp/Extensions.cs
+++ b/lib/PuppeteerSharp/Extensions.cs
@@ -68,7 +68,7 @@ namespace PuppeteerSharp
         /// <typeparam name="T">The type of the response</typeparam>
         /// <param name="elementHandle">An <see cref="ElementHandle"/> that will be used as the first argument in <paramref name="pageFunction"/></param>
         /// <param name="pageFunction">Function to be evaluated in browser context</param>
-        /// <param name="disposeHandle">If set to <c>false</c> the <paramref name="elementHandle"/> will not be disposed. Only opt out of disposure if the <paramref name="pageFunction"/> is a pure function with no side effects on the <paramref name="elementHandle"/>.</param>
+        /// <param name="disposeHandle">If set to <c>false</c> the <paramref name="elementHandle"/> will not be disposed. Only opt out of disposal if the <paramref name="pageFunction"/> is a pure function with no side effects on the <paramref name="elementHandle"/>.</param>
         /// <param name="args">Arguments to pass to <c>pageFunction</c></param>
         /// <returns>Task which resolves to the return value of <c>pageFunction</c></returns>
         /// <exception cref="SelectorException">If <paramref name="elementHandle"/> is <c>null</c></exception>
@@ -139,7 +139,7 @@ namespace PuppeteerSharp
         /// <typeparam name="T"></typeparam>
         /// <param name="arrayHandle">An <see cref="JSHandle"/> that represents an array of <see cref="ElementHandle"/> that will be used as the first argument in <paramref name="pageFunction"/></param>
         /// <param name="pageFunction">Function to be evaluated in browser context</param>
-        /// <param name="disposeHandle">If set to <c>false</c> the <paramref name="arrayHandle"/> will not be disposed. Only opt out of disposure if the <paramref name="pageFunction"/> is a pure function with no side effects on the <paramref name="arrayHandle"/>.</param>
+        /// <param name="disposeHandle">If set to <c>false</c> the <paramref name="arrayHandle"/> will not be disposed. Only opt out of disposal if the <paramref name="pageFunction"/> is a pure function with no side effects on the <paramref name="arrayHandle"/>.</param>
         /// <param name="args">Arguments to pass to <c>pageFunction</c></param>
         /// <returns>Task which resolves to the return value of <c>pageFunction</c></returns>
         public static async Task<T> EvaluateFunctionAsync<T>(this JSHandle arrayHandle, string pageFunction, bool disposeHandle, params object[] args)

--- a/lib/PuppeteerSharp/Extensions.cs
+++ b/lib/PuppeteerSharp/Extensions.cs
@@ -63,6 +63,36 @@ namespace PuppeteerSharp
         }
 
         /// <summary>
+        /// Runs <paramref name="pageFunction"/> within the frame and passes it the outcome the <paramref name="elementHandle"/> as the first argument
+        /// </summary>
+        /// <typeparam name="T">The type of the response</typeparam>
+        /// <param name="elementHandle">An <see cref="ElementHandle"/> that will be used as the first argument in <paramref name="pageFunction"/></param>
+        /// <param name="pageFunction">Function to be evaluated in browser context</param>
+        /// <param name="disposeHandle">If set to <c>false</c> the <paramref name="elementHandle"/> will not be disposed. Only opt out of disposure if the <paramref name="pageFunction"/> is a pure function with no side effects on the <paramref name="elementHandle"/>.</param>
+        /// <param name="args">Arguments to pass to <c>pageFunction</c></param>
+        /// <returns>Task which resolves to the return value of <c>pageFunction</c></returns>
+        /// <exception cref="SelectorException">If <paramref name="elementHandle"/> is <c>null</c></exception>
+        public static async Task<T> EvaluateFunctionAsync<T>(this ElementHandle elementHandle, string pageFunction, bool disposeHandle, params object[] args)
+        {
+            if (elementHandle == null)
+            {
+                throw new SelectorException("Error: failed to find element matching selector");
+            }
+
+            var newArgs = new object[args.Length + 1];
+            newArgs[0] = elementHandle;
+            args.CopyTo(newArgs, 1);
+            var result = await elementHandle.ExecutionContext.EvaluateFunctionAsync<T>(pageFunction, newArgs).ConfigureAwait(false);
+
+            if (disposeHandle)
+            {
+                await elementHandle.DisposeAsync().ConfigureAwait(false);
+            }
+
+            return result;
+        }
+
+        /// <summary>
         /// Runs <paramref name="pageFunction"/> within the frame and passes it the outcome of <paramref name="arrayHandleTask"/> as the first argument. Use only after <see cref="Page.QuerySelectorAllHandleAsync(string)"/>
         /// </summary>
         /// <param name="arrayHandleTask">A task that returns an <see cref="JSHandle"/> that represents an array of <see cref="ElementHandle"/> that will be used as the first argument in <paramref name="pageFunction"/></param>
@@ -100,6 +130,32 @@ namespace PuppeteerSharp
             args.CopyTo(newArgs, 1);
             var result = await arrayHandle.ExecutionContext.EvaluateFunctionAsync<T>(pageFunction, newArgs).ConfigureAwait(false);
             await arrayHandle.DisposeAsync().ConfigureAwait(false);
+            return result;
+        }
+
+        /// <summary>
+        /// Runs <paramref name="pageFunction"/> within the frame and passes it the outcome of <paramref name="arrayHandle"/> as the first argument. Use only after <see cref="Page.QuerySelectorAllHandleAsync(string)"/>
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="arrayHandle">An <see cref="JSHandle"/> that represents an array of <see cref="ElementHandle"/> that will be used as the first argument in <paramref name="pageFunction"/></param>
+        /// <param name="pageFunction">Function to be evaluated in browser context</param>
+        /// <param name="disposeHandle">If set to <c>false</c> the <paramref name="arrayHandle"/> will not be disposed. Only opt out of disposure if the <paramref name="pageFunction"/> is a pure function with no side effects on the <paramref name="arrayHandle"/>.</param>
+        /// <param name="args">Arguments to pass to <c>pageFunction</c></param>
+        /// <returns>Task which resolves to the return value of <c>pageFunction</c></returns>
+        public static async Task<T> EvaluateFunctionAsync<T>(this JSHandle arrayHandle, string pageFunction, bool disposeHandle, params object[] args)
+        {
+            var response = await arrayHandle.JsonValueAsync<object[]>().ConfigureAwait(false);
+
+            var newArgs = new object[args.Length + 1];
+            newArgs[0] = arrayHandle;
+            args.CopyTo(newArgs, 1);
+            var result = await arrayHandle.ExecutionContext.EvaluateFunctionAsync<T>(pageFunction, newArgs).ConfigureAwait(false);
+
+            if (disposeHandle)
+            {
+                await arrayHandle.DisposeAsync().ConfigureAwait(false);
+            }
+
             return result;
         }
     }


### PR DESCRIPTION
I would like to add a flag to the `EvaluateFunctionAsync` methods, to be able to opt out of the disposal of the element/array handle.

If the page function is pure with no side effects on the element/array handle, then this could be possible.

Consider this scenario:

```
await Page.SetContentAsync("<section id='testAttribute'>43543</section>");
var section = await Page.QuerySelectorAsync("section");
var idAttribute = await section.EvaluateFunctionAsync<string>("e => e.id", disposeHandle: false);
var text = await section.EvaluateFunctionAsync<string>("e => e.textContent", disposeHandle: false);
```

Here we can avoid the `EvaluationFailedException` (JSHandle is disposed!), when evaluating two functions on the same element.