### PR TITLE
Connection messages should be dispatched synchronously

### DIFF
--- a/lib/PuppeteerSharp/CDPSession.cs
+++ b/lib/PuppeteerSharp/CDPSession.cs
@@ -157,7 +157,7 @@ namespace PuppeteerSharp
             {
                 callback = new MessageTask
                 {
-                    TaskWrapper = new TaskCompletionSource<JObject>(TaskCreationOptions.RunContinuationsAsynchronously),
+                    TaskWrapper = new TaskCompletionSource<JObject>(),
                     Method = method
                 };
                 _callbacks[id] = callback;

--- a/lib/PuppeteerSharp/Connection.cs
+++ b/lib/PuppeteerSharp/Connection.cs
@@ -109,7 +109,7 @@ namespace PuppeteerSharp
             {
                 callback = new MessageTask
                 {
-                    TaskWrapper = new TaskCompletionSource<JObject>(TaskCreationOptions.RunContinuationsAsynchronously),
+                    TaskWrapper = new TaskCompletionSource<JObject>(),
                     Method = method
                 };
                 _callbacks[id] = callback;

--- a/lib/PuppeteerSharp/PageCoverage/CSSCoverage.cs
+++ b/lib/PuppeteerSharp/PageCoverage/CSSCoverage.cs
@@ -105,7 +105,7 @@ namespace PuppeteerSharp.PageCoverage
                 switch (e.MessageID)
                 {
                     case "CSS.styleSheetAdded":
-                        await OnStyleSheetAdded(e.MessageData.ToObject<CSSStyleSheetAddedResponse>(true)).ConfigureAwait(false);
+                        await OnStyleSheetAddedAsync(e.MessageData.ToObject<CSSStyleSheetAddedResponse>(true)).ConfigureAwait(false);
                         break;
                     case "Runtime.executionContextsCleared":
                         OnExecutionContextsCleared();
@@ -120,7 +120,7 @@ namespace PuppeteerSharp.PageCoverage
             }
         }
 
-        private async Task OnStyleSheetAdded(CSSStyleSheetAddedResponse styleSheetAddedResponse)
+        private async Task OnStyleSheetAddedAsync(CSSStyleSheetAddedResponse styleSheetAddedResponse)
         {
             if (string.IsNullOrEmpty(styleSheetAddedResponse.Header.SourceURL))
             {

--- a/lib/PuppeteerSharp/PageCoverage/JSCoverage.cs
+++ b/lib/PuppeteerSharp/PageCoverage/JSCoverage.cs
@@ -103,7 +103,7 @@ namespace PuppeteerSharp.PageCoverage
                 switch (e.MessageID)
                 {
                     case "Debugger.scriptParsed":
-                        await OnScriptParsed(e.MessageData.ToObject<DebuggerScriptParsedResponse>(true)).ConfigureAwait(false);
+                        await OnScriptParsedAsync(e.MessageData.ToObject<DebuggerScriptParsedResponse>(true)).ConfigureAwait(false);
                         break;
                     case "Runtime.executionContextsCleared":
                         OnExecutionContextsCleared();
@@ -118,7 +118,7 @@ namespace PuppeteerSharp.PageCoverage
             }
         }
 
-        private async Task OnScriptParsed(DebuggerScriptParsedResponse scriptParseResponse)
+        private async Task OnScriptParsedAsync(DebuggerScriptParsedResponse scriptParseResponse)
         {
             if (scriptParseResponse.Url == ExecutionContext.EvaluationScriptUrl ||
                 (string.IsNullOrEmpty(scriptParseResponse.Url) && !_reportAnonymousScripts))


### PR DESCRIPTION
We need to dispatch connections events as soon as possible. This changed brought many racing conditions.
