### PR TITLE
SetContentAsync improvements

### DIFF
--- a/lib/PuppeteerSharp/Frame.cs
+++ b/lib/PuppeteerSharp/Frame.cs
@@ -557,6 +557,7 @@ namespace PuppeteerSharp
         {
             var waitUntil = options?.WaitUntil ?? new[] { WaitUntilNavigation.Load };
             var timeout = options?.Timeout ?? Puppeteer.DefaultTimeout;
+            var watcher = new LifecycleWatcher(FrameManager, this, waitUntil, timeout);
 
             // We rely upon the fact that document.open() will reset frame lifecycle with "init"
             // lifecycle event. @see https://crrev.com/608658
@@ -565,8 +566,6 @@ namespace PuppeteerSharp
                 document.write(html);
                 document.close();
             }", html);
-
-            var watcher = new LifecycleWatcher(FrameManager, this, waitUntil, timeout);
 
             var watcherTask = await Task.WhenAny(
                 watcher.TimeoutOrTerminationTask,


### PR DESCRIPTION
Load LifecycleWatcher before injecting the HTML.

This might have caused this hang https://ci.appveyor.com/project/kblok/puppeteer-sharp/builds/21440654/job/g6ev4p72raqk64k8/tests