### PR TITLE
Warn on nested js handle

### DIFF
--- a/lib/PuppeteerSharp.Tests/PageTests/EvaluateTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/EvaluateTests.cs
@@ -4,7 +4,7 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Xunit;
 using Xunit.Abstractions;
-using PuppeteerSharp.Helpers;
+using PuppeteerSharp.Helpers.Json;
 
 namespace PuppeteerSharp.Tests.PageTests
 {
@@ -175,6 +175,18 @@ namespace PuppeteerSharp.Tests.PageTests
             var aHandle = await Page.EvaluateExpressionHandleAsync("5");
             var isFive = await Page.EvaluateFunctionAsync<bool>("e => Object.is(e, 5)", aHandle);
             Assert.True(isFive);
+        }
+
+        [Fact]
+        public async Task ShouldWarnOnNestedObjectHandles()
+        {
+            var aHandle = await Page.EvaluateFunctionHandleAsync("() => document.body");
+            var exception = await Assert.ThrowsAsync<EvaluationFailedException>(()
+                => Page.EvaluateFunctionHandleAsync(
+                    "opts => opts.elem.querySelector('p')",
+                    new { elem = aHandle }));
+
+            Assert.Contains("Are you passing a nested JSHandle?", exception.Message);
         }
 
         [Fact]

--- a/lib/PuppeteerSharp.Tests/PageTests/EvaluateTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/EvaluateTests.cs
@@ -180,11 +180,21 @@ namespace PuppeteerSharp.Tests.PageTests
         [Fact]
         public async Task ShouldWarnOnNestedObjectHandles()
         {
-            var aHandle = await Page.EvaluateFunctionHandleAsync("() => document.body");
+            var handle = await Page.EvaluateFunctionHandleAsync("() => document.body");
+            var elementHandle = handle as ElementHandle;
+
             var exception = await Assert.ThrowsAsync<EvaluationFailedException>(()
                 => Page.EvaluateFunctionHandleAsync(
                     "opts => opts.elem.querySelector('p')",
-                    new { elem = aHandle }));
+                    new { elem = handle }));
+
+            Assert.Contains("Are you passing a nested JSHandle?", exception.Message);
+
+            //Check with ElementHandle
+            exception = await Assert.ThrowsAsync<EvaluationFailedException>(()
+                => Page.EvaluateFunctionHandleAsync(
+                    "opts => opts.elem.querySelector('p')",
+                    new { elem = elementHandle }));
 
             Assert.Contains("Are you passing a nested JSHandle?", exception.Message);
         }

--- a/lib/PuppeteerSharp/Browser.cs
+++ b/lib/PuppeteerSharp/Browser.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using PuppeteerSharp.Helpers;
+using PuppeteerSharp.Helpers.Json;
 using PuppeteerSharp.Messaging;
 
 namespace PuppeteerSharp

--- a/lib/PuppeteerSharp/CDPSession.cs
+++ b/lib/PuppeteerSharp/CDPSession.cs
@@ -1,14 +1,12 @@
 ﻿using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using Newtonsoft.Json.Serialization;
-using PuppeteerSharp.Helpers;
+using PuppeteerSharp.Helpers.Json;
 using PuppeteerSharp.Messaging;
 
 namespace PuppeteerSharp

--- a/lib/PuppeteerSharp/Connection.cs
+++ b/lib/PuppeteerSharp/Connection.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Linq;
 using System.Net.WebSockets;
 using System.Threading;
@@ -8,7 +7,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using PuppeteerSharp.Helpers;
+using PuppeteerSharp.Helpers.Json;
 using PuppeteerSharp.Messaging;
 using PuppeteerSharp.Transport;
 

--- a/lib/PuppeteerSharp/ElementHandle.cs
+++ b/lib/PuppeteerSharp/ElementHandle.cs
@@ -1,11 +1,10 @@
 ﻿using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using PuppeteerSharp.Helpers;
+using PuppeteerSharp.Helpers.Json;
 using PuppeteerSharp.Input;
 using PuppeteerSharp.Messaging;
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;

--- a/lib/PuppeteerSharp/FrameManager.cs
+++ b/lib/PuppeteerSharp/FrameManager.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using PuppeteerSharp.Helpers;
+using PuppeteerSharp.Helpers.Json;
 using PuppeteerSharp.Messaging;
 
 namespace PuppeteerSharp

--- a/lib/PuppeteerSharp/Helpers/Json/FlexibleStringEnumConverter.cs
+++ b/lib/PuppeteerSharp/Helpers/Json/FlexibleStringEnumConverter.cs
@@ -2,7 +2,7 @@
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 
-namespace PuppeteerSharp.Helpers
+namespace PuppeteerSharp.Helpers.Json
 {
     internal class FlexibleStringEnumConverter : StringEnumConverter
     {

--- a/lib/PuppeteerSharp/Helpers/Json/HttpMethodConverter.cs
+++ b/lib/PuppeteerSharp/Helpers/Json/HttpMethodConverter.cs
@@ -2,16 +2,14 @@
 using System.Net.Http;
 using Newtonsoft.Json;
 
-namespace PuppeteerSharp.Helpers
+namespace PuppeteerSharp.Helpers.Json
 {
     internal class HttpMethodConverter : JsonConverter
     {
         public override bool CanConvert(Type objectType) => objectType == typeof(string);
 
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
-        {
-            return new HttpMethod((string)reader.Value);
-        }
+            => new HttpMethod((string)reader.Value);
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {

--- a/lib/PuppeteerSharp/Helpers/Json/JSHandleMethodConverter.cs
+++ b/lib/PuppeteerSharp/Helpers/Json/JSHandleMethodConverter.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace PuppeteerSharp.Helpers.Json
+{
+    /// <summary>
+    /// JSHandleMethodConverter will throw an exception if a JSHandle object is trying to be serialized
+    /// </summary>
+    internal class JSHandleMethodConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType) => false;
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+            => null;
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+            => throw new EvaluationFailedException("Unable to make function call. Are you passing a nested JSHandle?");
+    }
+}

--- a/lib/PuppeteerSharp/Helpers/Json/JTokenExtensions.cs
+++ b/lib/PuppeteerSharp/Helpers/Json/JTokenExtensions.cs
@@ -2,7 +2,7 @@
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
 
-namespace PuppeteerSharp.Helpers
+namespace PuppeteerSharp.Helpers.Json
 {
     /// <summary>
     /// A set of extension methods for JToken

--- a/lib/PuppeteerSharp/Helpers/Json/JsonHelper.cs
+++ b/lib/PuppeteerSharp/Helpers/Json/JsonHelper.cs
@@ -1,7 +1,7 @@
 ﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
-namespace PuppeteerSharp.Helpers
+namespace PuppeteerSharp.Helpers.Json
 {
     internal static class JsonHelper
     {

--- a/lib/PuppeteerSharp/Helpers/RemoteObjectHelper.cs
+++ b/lib/PuppeteerSharp/Helpers/RemoteObjectHelper.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Linq;
 using PuppeteerSharp.Messaging;
+using PuppeteerSharp.Helpers.Json;
 
 namespace PuppeteerSharp.Helpers
 {

--- a/lib/PuppeteerSharp/JSHandle.cs
+++ b/lib/PuppeteerSharp/JSHandle.cs
@@ -1,8 +1,9 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json.Linq;
+using Newtonsoft.Json;
 using PuppeteerSharp.Helpers;
+using PuppeteerSharp.Helpers.Json;
 using PuppeteerSharp.Messaging;
 
 namespace PuppeteerSharp
@@ -10,6 +11,7 @@ namespace PuppeteerSharp
     /// <summary>
     /// JSHandle represents an in-page JavaScript object. JSHandles can be created with the <see cref="Page.EvaluateExpressionHandleAsync(string)"/> and <see cref="Page.EvaluateFunctionHandleAsync(string, object[])"/> methods.
     /// </summary>
+    [JsonConverter(typeof(JSHandleMethodConverter))]
     public class JSHandle
     {
         internal JSHandle(ExecutionContext context, CDPSession client, RemoteObject remoteObject)

--- a/lib/PuppeteerSharp/Messaging/BindingCalledResponse.cs
+++ b/lib/PuppeteerSharp/Messaging/BindingCalledResponse.cs
@@ -1,7 +1,6 @@
 ﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using Newtonsoft.Json.Serialization;
-using PuppeteerSharp.Helpers;
+using PuppeteerSharp.Helpers.Json;
 
 namespace PuppeteerSharp.Messaging
 {

--- a/lib/PuppeteerSharp/Messaging/RemoteObjectSubtype.cs
+++ b/lib/PuppeteerSharp/Messaging/RemoteObjectSubtype.cs
@@ -1,5 +1,5 @@
 ﻿using Newtonsoft.Json;
-using PuppeteerSharp.Helpers;
+using PuppeteerSharp.Helpers.Json;
 
 namespace PuppeteerSharp.Messaging
 {

--- a/lib/PuppeteerSharp/Messaging/RemoteObjectType.cs
+++ b/lib/PuppeteerSharp/Messaging/RemoteObjectType.cs
@@ -1,5 +1,5 @@
 ﻿using Newtonsoft.Json;
-using PuppeteerSharp.Helpers;
+using PuppeteerSharp.Helpers.Json;
 
 namespace PuppeteerSharp.Messaging
 {

--- a/lib/PuppeteerSharp/NetworkManager.cs
+++ b/lib/PuppeteerSharp/NetworkManager.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using PuppeteerSharp.Helpers;
+using PuppeteerSharp.Helpers.Json;
 using PuppeteerSharp.Messaging;
 
 namespace PuppeteerSharp

--- a/lib/PuppeteerSharp/Page.cs
+++ b/lib/PuppeteerSharp/Page.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using PuppeteerSharp.Helpers;
+using PuppeteerSharp.Helpers.Json;
 using PuppeteerSharp.Input;
 using PuppeteerSharp.Media;
 using PuppeteerSharp.Messaging;

--- a/lib/PuppeteerSharp/PageCoverage/CSSCoverage.cs
+++ b/lib/PuppeteerSharp/PageCoverage/CSSCoverage.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
-using PuppeteerSharp.Helpers;
+using PuppeteerSharp.Helpers.Json;
 using PuppeteerSharp.Messaging;
 
 namespace PuppeteerSharp.PageCoverage

--- a/lib/PuppeteerSharp/PageCoverage/JSCoverage.cs
+++ b/lib/PuppeteerSharp/PageCoverage/JSCoverage.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
-using PuppeteerSharp.Helpers;
+using PuppeteerSharp.Helpers.Json;
 using PuppeteerSharp.Messaging;
 
 namespace PuppeteerSharp.PageCoverage

--- a/lib/PuppeteerSharp/Payload.cs
+++ b/lib/PuppeteerSharp/Payload.cs
@@ -4,8 +4,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Web;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
-using PuppeteerSharp.Helpers;
+using PuppeteerSharp.Helpers.Json;
 
 namespace PuppeteerSharp
 {

--- a/lib/PuppeteerSharp/PuppeteerSharp.csproj
+++ b/lib/PuppeteerSharp/PuppeteerSharp.csproj
@@ -53,4 +53,7 @@
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.0.2" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.1" />
   </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Helpers\Json\" />
+  </ItemGroup>
 </Project>

--- a/lib/PuppeteerSharp/ResourceType.cs
+++ b/lib/PuppeteerSharp/ResourceType.cs
@@ -1,6 +1,5 @@
 ﻿using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
-using PuppeteerSharp.Helpers;
+using PuppeteerSharp.Helpers.Json;
 using System.Runtime.Serialization;
 
 namespace PuppeteerSharp

--- a/lib/PuppeteerSharp/Response.cs
+++ b/lib/PuppeteerSharp/Response.cs
@@ -5,7 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using PuppeteerSharp.Messaging;
-using PuppeteerSharp.Helpers;
+using PuppeteerSharp.Helpers.Json;
 
 namespace PuppeteerSharp
 {

--- a/lib/PuppeteerSharp/TargetType.cs
+++ b/lib/PuppeteerSharp/TargetType.cs
@@ -1,7 +1,6 @@
 ﻿using System.Runtime.Serialization;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
-using PuppeteerSharp.Helpers;
+using PuppeteerSharp.Helpers.Json;
 
 namespace PuppeteerSharp
 {

--- a/lib/PuppeteerSharp/Worker.cs
+++ b/lib/PuppeteerSharp/Worker.cs
@@ -2,9 +2,8 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json.Linq;
 using PuppeteerSharp.Messaging;
-using PuppeteerSharp.Helpers;
+using PuppeteerSharp.Helpers.Json;
 
 namespace PuppeteerSharp
 {


### PR DESCRIPTION
We are not getting a `Converting circular structure to JSON` when we try to serialize a JSHandle, and I also consider that's not the best way to infer that, we can do better in C#
So I created a JSHandlerCoverter which will throw that exception is someone is trying to send a JSHandle.