### PR TITLE
Bug (NetworkManger): The key already existed in the dictionary 

### DIFF
--- a/lib/PuppeteerSharp/Helpers/MultiMap.cs
+++ b/lib/PuppeteerSharp/Helpers/MultiMap.cs
@@ -9,17 +9,7 @@ namespace PuppeteerSharp.Helpers
         private readonly ConcurrentDictionary<TKey, List<TValue>> _map = new ConcurrentDictionary<TKey, List<TValue>>();
 
         internal void Add(TKey key, TValue value)
-        {
-            if (_map.TryGetValue(key, out var set))
-            {
-                set.Add(value);
-            }
-            else
-            {
-                set = new List<TValue> { value };
-                _map.TryAdd(key, set);
-            }
-        }
+            => _map.GetOrAdd(key, k => new List<TValue>()).Add(value);
 
         internal List<TValue> Get(TKey key)
             => _map.TryGetValue(key, out var set) ? set : new List<TValue>();


### PR DESCRIPTION
Recently we have been seeing the following under load: 

```
ex_msg: The key already existed in the dictionary. | stacktrace: System.ArgumentException: The key already existed in the dictionary.
   at System.Collections.Concurrent.ConcurrentDictionary`2.System.Collections.Generic.IDictionary<TKey,TValue>.Add(TKey key, TValue value)
   at PuppeteerSharp.NetworkManager.<OnRequestWillBeSentAsync>d__44.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.GetResult()
   at PuppeteerSharp.NetworkManager.<Client_MessageReceived>d__36.MoveNext()
```

This PR looks at some of the causes for this. We are still testing the changes, but wanted to get this here for your visibility and thoughts also.

I've managed to:
- Remove two of the dictionaries that were previously required
- Optimise the way some of the dictionaries were used (ie: using TryRemove instead of Get/Remove)
- Fixed up some event invocation handling
- Fixed a few minor race conditions (ie: MultiMap.Add - note that there is still a problem when the list needs to grow the array, but from what I can see the default capacity should be enough to warrant not locking)

... all whilst _hopefully_ kept the same semantics.

_It'd be really nice if chrome fixed the mentioned bug and started to send back the request id, then the entire class could be handled with a single ConcurrentDictionary. I know this is not you though ;)_