### PR TITLE
Always dispose cancellation token sources

### DIFF
--- a/lib/PuppeteerSharp/Helpers/TaskHelper.cs
+++ b/lib/PuppeteerSharp/Helpers/TaskHelper.cs
@@ -93,20 +93,21 @@ namespace PuppeteerSharp.Helpers
         private static async Task<bool> TimeoutTask(Task task, int milliseconds)
         {
             var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-            var cancellationToken = new CancellationTokenSource();
-
-            if (milliseconds > 0)
+            using (var cancellationToken = new CancellationTokenSource())
             {
-                cancellationToken.CancelAfter(milliseconds);
-            }
-            using (cancellationToken.Token.Register(s => ((TaskCompletionSource<bool>)s).TrySetResult(true), tcs))
-            {
-                if (task != await Task.WhenAny(task, tcs.Task))
+                if (milliseconds > 0)
                 {
-                    return true;
+                    cancellationToken.CancelAfter(milliseconds);
                 }
+                using (cancellationToken.Token.Register(s => ((TaskCompletionSource<bool>)s).TrySetResult(true), tcs))
+                {
+                    if (task != await Task.WhenAny(task, tcs.Task))
+                    {
+                        return true;
+                    }
+                }
+                return false;
             }
-            return false;
         }
     }
 }


### PR DESCRIPTION
If `CancellationTokenSource`'s aren't disposed, then there timers are left on the timer queue. Internally, the timer queue runs through each timer to determine whether or not to fire the said time, as it's implemented as a linked list. So this not only clears up the timer resources, but makes the other times more "accurate" as there is less work to do.