### PR TITLE
Bug (NetworkManger): The key already existed in the dictionary

### DIFF
--- a/lib/PuppeteerSharp/Helpers/MultiMap.cs
+++ b/lib/PuppeteerSharp/Helpers/MultiMap.cs
@@ -9,17 +9,7 @@ namespace PuppeteerSharp.Helpers
         private readonly ConcurrentDictionary<TKey, List<TValue>> _map = new ConcurrentDictionary<TKey, List<TValue>>();
 
         internal void Add(TKey key, TValue value)
-        {
-            if (_map.TryGetValue(key, out var set))
-            {
-                set.Add(value);
-            }
-            else
-            {
-                set = new List<TValue> { value };
-                _map.TryAdd(key, set);
-            }
-        }
+            => _map.GetOrAdd(key, k => new List<TValue>()).Add(value);
 
         internal List<TValue> Get(TKey key)
             => _map.TryGetValue(key, out var set) ? set : new List<TValue>();

--- a/lib/PuppeteerSharp/NetworkManager.cs
+++ b/lib/PuppeteerSharp/NetworkManager.cs
@@ -14,8 +14,8 @@ namespace PuppeteerSharp
         #region Private members
 
         private readonly CDPSession _client;
-        private readonly IDictionary<string, Request> _requestIdToRequest = new ConcurrentDictionary<string, Request>();
-        private readonly IDictionary<string, RequestWillBeSentPayload> _requestIdToRequestWillBeSentEvent =
+        private readonly ConcurrentDictionary<string, Request> _requestIdToRequest = new ConcurrentDictionary<string, Request>();
+        private readonly ConcurrentDictionary<string, RequestWillBeSentPayload> _requestIdToRequestWillBeSentEvent =
             new ConcurrentDictionary<string, RequestWillBeSentPayload>();
         private readonly MultiMap<string, string> _requestHashToRequestIds = new MultiMap<string, string>();
         private readonly MultiMap<string, string> _requestHashToInterceptionIds = new MultiMap<string, string>();
@@ -142,14 +142,14 @@ namespace PuppeteerSharp
             {
                 request.Failure = e.ErrorText;
                 request.Response?.BodyLoadedTaskWrapper.TrySetResult(true);
-                _requestIdToRequest.Remove(request.RequestId);
+                _requestIdToRequest.TryRemove(request.RequestId, out _);
 
                 if (request.InterceptionId != null)
                 {
                     _attemptedAuthentications.Remove(request.InterceptionId);
                 }
 
-                RequestFailed(this, new RequestEventArgs
+                RequestFailed?.Invoke(this, new RequestEventArgs
                 {
                     Request = request
                 });
@@ -163,7 +163,7 @@ namespace PuppeteerSharp
             if (_requestIdToRequest.TryGetValue(e.RequestId, out var request))
             {
                 request.Response?.BodyLoadedTaskWrapper.TrySetResult(true);
-                _requestIdToRequest.Remove(request.RequestId);
+                _requestIdToRequest.TryRemove(request.RequestId, out _);
 
                 if (request.InterceptionId != null)
                 {
@@ -249,13 +249,10 @@ namespace PuppeteerSharp
             var requestId = _requestHashToRequestIds.FirstValue(requestHash);
             if (requestId != null)
             {
-                _requestIdToRequestWillBeSentEvent.TryGetValue(requestId, out var requestWillBeSentEvent);
-
-                if (requestWillBeSentEvent != null)
+                if (_requestIdToRequestWillBeSentEvent.TryRemove(requestId, out var requestWillBeSentEvent))
                 {
                     await OnRequestAsync(requestWillBeSentEvent, e.InterceptionId);
                     _requestHashToRequestIds.Delete(requestHash, requestId);
-                    _requestIdToRequestWillBeSentEvent.Remove(requestId);
                 }
             }
             else
@@ -293,7 +290,7 @@ namespace PuppeteerSharp
 
                 _requestIdToRequest[e.RequestId] = request;
 
-                Request(this, new RequestEventArgs
+                Request?.Invoke(this, new RequestEventArgs
                 {
                     Request = request
                 });
@@ -322,7 +319,7 @@ namespace PuppeteerSharp
 
             if (request.RequestId != null)
             {
-                _requestIdToRequest.Remove(request.RequestId);
+                _requestIdToRequest.TryRemove(request.RequestId, out _);
             }
 
             if (request.InterceptionId != null)
@@ -330,12 +327,12 @@ namespace PuppeteerSharp
                 _attemptedAuthentications.Remove(request.InterceptionId);
             }
 
-            Response(this, new ResponseCreatedEventArgs
+            Response?.Invoke(this, new ResponseCreatedEventArgs
             {
                 Response = response
             });
 
-            RequestFinished(this, new RequestEventArgs
+            RequestFinished?.Invoke(this, new RequestEventArgs
             {
                 Request = request
             });
@@ -356,7 +353,8 @@ namespace PuppeteerSharp
                 else
                 {
                     _requestHashToRequestIds.Add(requestHash, e.RequestId);
-                    _requestIdToRequestWillBeSentEvent.Add(e.RequestId, e);
+                    // Under load, we may get to this section more than once
+                    _requestIdToRequestWillBeSentEvent.TryAdd(e.RequestId, e);
                 }
                 return;
             }


### PR DESCRIPTION
_Alternative To [This PR](https://github.com/kblok/puppeteer-sharp/pull/925). Decided that I don't know enough about how chrome works to be fiddling with there and i'm running out of in-work time. So fixing the exception by using `TryAdd` instead as well as fixing the other small things. Dictionary accesses are otherwise left as is. Duplicated the PR description for future reference._

Recently we have been seeing the following under load: 

```
ex_msg: The key already existed in the dictionary. | stacktrace: System.ArgumentException: The key already existed in the dictionary.
   at System.Collections.Concurrent.ConcurrentDictionary`2.System.Collections.Generic.IDictionary<TKey,TValue>.Add(TKey key, TValue value)
   at PuppeteerSharp.NetworkManager.<OnRequestWillBeSentAsync>d__44.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.GetResult()
   at PuppeteerSharp.NetworkManager.<Client_MessageReceived>d__36.MoveNext()
```

This PR looks at some of the causes for this. We are still testing the changes, but wanted to get this here for your visibility and thoughts also.

I've managed to:
- Remove two of the dictionaries that were previously required
- Optimise the way some of the dictionaries were used (ie: using TryRemove instead of Get/Remove)
- Fixed up some event invocation handling
- Fixed a few minor race conditions (ie: MultiMap.Add - note that there is still a problem when the list needs to grow the array, but from what I can see the default capacity should be enough to warrant not locking)

... all whilst _hopefully_ kept the same semantics.

_It'd be really nice if chrome fixed the mentioned bug and started to send back the request id, then the entire class could be handled with a single ConcurrentDictionary. I know this is not you though ;)_