### PR TITLE
Make Target class resposible for its own state management

### DIFF
--- a/lib/PuppeteerSharp/AbstractStateMachine.cs
+++ b/lib/PuppeteerSharp/AbstractStateMachine.cs
@@ -1,0 +1,60 @@
+﻿namespace PuppeteerSharp
+{
+    using System;
+    using System.Runtime.CompilerServices;
+    using System.Threading;
+
+    internal interface IStateMachine<TState>
+    {
+        TState CurrentState { get; }
+        bool TryEnter(TState newState, TState fromState);
+    }
+
+    /// <summary>
+    /// Base class for states.
+    /// </summary>
+    internal abstract class AbstractState<TContext, TState>
+        where TContext : IStateMachine<TState>
+        where TState : AbstractState<TContext, TState>
+    {
+        /// <summary>
+        /// Attempts thread-safe transitions from a given state to this state.
+        /// </summary>
+        /// <param name="context">The state machine</param>
+        /// <param name="fromState">The state from which state transition takes place</param>
+        /// <returns>Returns <c>true</c> if transition is successful, or <c>false</c> if transition
+        /// cannot be made because current state does not equal <paramref name="fromState"/>.</returns>
+        protected bool TryEnter(TContext context, TState fromState)
+        {
+            if (context.TryEnter((TState)this, fromState))
+            {
+                fromState.Leave(context);
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Notifies that state machine is about to transition to another state.
+        /// </summary>
+        /// <param name="context">The state machine</param>
+        protected virtual void Leave(TContext context)
+        { }
+
+        /// <inheritdoc />
+        public override string ToString()
+        {
+            var name = GetType().Name;
+            return name.Substring(0, name.Length - "State".Length);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="InvalidOperationException"/>.
+        /// </summary>
+        /// <param name="operationName">The operation name, defaults to name of direct caller.</param>
+        /// <returns>An <see cref="InvalidOperationException"/> for the specified <paramref name="operationName"/>.</returns>
+        protected Exception InvalidOperation([CallerMemberName] string operationName = null)
+            => new InvalidOperationException($"Cannot {operationName.Replace("Async", null)} in state {this}");
+    }
+}

--- a/lib/PuppeteerSharp/BrowserContext.cs
+++ b/lib/PuppeteerSharp/BrowserContext.cs
@@ -8,7 +8,7 @@ namespace PuppeteerSharp
 {
     /// <summary>
     /// BrowserContexts provide a way to operate multiple independent browser sessions. When a browser is launched, it has
-    /// a single <see cref="BrowserContext"/> used by default. The method <see cref="Browser.NewPageAsync"/> creates a <see cref="Page"/> in the default <see cref="BrowserContext"/>
+    /// a single <see cref="BrowserContext"/> used by default. The method <see cref="PuppeteerSharp.Browser.NewPageAsync"/> creates a <see cref="Page"/> in the default <see cref="BrowserContext"/>
     /// </summary>
     public class BrowserContext
     {

--- a/lib/PuppeteerSharp/Page.cs
+++ b/lib/PuppeteerSharp/Page.cs
@@ -79,12 +79,15 @@ namespace PuppeteerSharp
             _ignoreHTTPSErrors = ignoreHTTPSErrors;
 
             _screenshotTaskQueue = screenshotTaskQueue;
-            target.CloseTask.ContinueWith((arg) =>
+
+            _ = OnTargetClosedAsync();
+            async Task OnTargetClosedAsync()
             {
+                await Target.CloseTask.ConfigureAwait(false);
                 Close?.Invoke(this, EventArgs.Empty);
                 IsClosed = true;
                 _closeCompletedTcs.TrySetResult(true);
-            });
+            }
 
             Client.MessageReceived += Client_MessageReceived;
         }
@@ -1101,10 +1104,7 @@ namespace PuppeteerSharp
                 }
                 else
                 {
-                    return Client.Connection.SendAsync("Target.closeTarget", new TargetCloseTargetRequest
-                    {
-                        TargetId = Target.TargetId
-                    }).ContinueWith((task) => Target.CloseTask);
+                    return Target.CloseAsync();
                 }
             }
 

--- a/lib/PuppeteerSharp/Target.cs
+++ b/lib/PuppeteerSharp/Target.cs
@@ -1,82 +1,80 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Threading;
 using System.Threading.Tasks;
-using PuppeteerSharp.Helpers;
+using PuppeteerSharp.Messaging;
 
 namespace PuppeteerSharp
 {
     /// <summary>
     /// Target.
     /// </summary>
-    [DebuggerDisplay("Target {Type} - {Url}")]
-    public class Target
+    [DebuggerDisplay("Target {Type} - {Url} - {_currentState}")]
+    public class Target : IStateMachine<Target.State>
     {
         #region Private members
+
+        private State _currentState = State.Initial;
         private TargetInfo _targetInfo;
-        private readonly string _targetId;
         private readonly Func<TargetInfo, Task<CDPSession>> _sessionFactory;
+        private readonly TaskCompletionSource<bool> _initializeTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        private Task<Page> _pageTask;
+        private readonly TaskCompletionSource<bool> _closeTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
         #endregion
 
-        internal bool IsInitialized;
+        #region Constructor(s)
 
-        internal Target(
-            TargetInfo targetInfo,
-            Func<TargetInfo, Task<CDPSession>> sessionFactory,
-            BrowserContext browserContext)
+        internal Target(TargetInfo targetInfo, Func<TargetInfo, Task<CDPSession>> sessionFactory, BrowserContext browserContext)
         {
-            _targetInfo = targetInfo;
-            _targetId = targetInfo.TargetId;
-            _sessionFactory = sessionFactory;
             BrowserContext = browserContext;
-            PageTask = null;
+            _sessionFactory = sessionFactory;
+            _currentState.SetTargetInfo(this, targetInfo);
 
-            InitilizedTaskWrapper = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-            InitilizedTaskWrapper.Task.ContinueWith(async initializedTask =>
+            _ = AfterInitializeAsync();
+            async Task<bool> AfterInitializeAsync()
             {
-                var success = initializedTask.Result;
-                if (!success)
+                var success = await _initializeTcs.Task;
+                if (success)
                 {
-                    return;
+                    if (Type == TargetType.Page)
+                    {
+                        var openerPageTask = Opener?.PageAsync();
+                        if (openerPageTask != null)
+                        {
+                            var openerPage = await openerPageTask.ConfigureAwait(false);
+                            if (openerPage.HasPopupEventListeners)
+                            {
+                                var popupPage = await PageAsync().ConfigureAwait(false);
+                                openerPage.OnPopup(popupPage);
+                            }
+                        }
+                    }
                 }
-                if (Opener == null || Opener.PageTask == null || Type != TargetType.Page)
-                {
-                    return;
-                }
-                var openerPage = await Opener.PageTask.ConfigureAwait(false);
-                if (!openerPage.HasPopupEventListeners)
-                {
-                    return;
-                }
-                var popupPage = await PageAsync().ConfigureAwait(false);
-                openerPage.OnPopup(popupPage);
-            });
-
-            CloseTaskWrapper = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-            IsInitialized = _targetInfo.Type != TargetType.Page || _targetInfo.Url != string.Empty;
-
-            if (IsInitialized)
-            {
-                InitilizedTaskWrapper.TrySetResult(true);
+                return success;
             }
         }
 
+        #endregion
+
         #region Properties
+
         /// <summary>
         /// Gets the URL.
         /// </summary>
         /// <value>The URL.</value>
-        public string Url => _targetInfo.Url;
+        public string Url => _targetInfo?.Url;
         /// <summary>
         /// Gets the type. It will be <see cref="TargetInfo.Type"/> if it's "page" or "service_worker". Otherwise it will be "other"
         /// </summary>
         /// <value>The type.</value>
-        public TargetType Type => _targetInfo.Type;
+        public TargetType Type => _targetInfo?.Type ?? 0;
 
         /// <summary>
         /// Gets the target identifier.
         /// </summary>
         /// <value>The target identifier.</value>
-        public string TargetId => _targetInfo.TargetId;
+        public string TargetId => _targetInfo?.TargetId;
 
         /// <summary>
         /// Get the target that opened this target
@@ -84,68 +82,216 @@ namespace PuppeteerSharp
         /// <remarks>
         /// Top-level targets return <c>null</c>.
         /// </remarks>
-        public Target Opener => _targetInfo.OpenerId != null ?
-            Browser.TargetsMap.GetValueOrDefault(_targetInfo.OpenerId) : null;
+        public Target Opener => _targetInfo?.OpenerId != null ? Browser.TargetById(_targetInfo.OpenerId) : null;
 
         /// <summary>
         /// Get the browser the target belongs to.
         /// </summary>
-        public Browser Browser => BrowserContext.Browser;
+        public Browser Browser => BrowserContext?.Browser;
 
         /// <summary>
         /// Get the browser context the target belongs to.
         /// </summary>
         public BrowserContext BrowserContext { get; }
 
-        internal Task<bool> InitializedTask => InitilizedTaskWrapper.Task;
-        internal TaskCompletionSource<bool> InitilizedTaskWrapper { get; }
-        internal Task CloseTask => CloseTaskWrapper.Task;
-        internal TaskCompletionSource<bool> CloseTaskWrapper { get; }
-        internal Task<Page> PageTask { get; set; }
+        internal bool IsInitialized => _initializeTcs.Task.IsCompleted && _initializeTcs.Task.Result;
+
+        private Task<bool> InitializeTask => _initializeTcs.Task;
+
+        internal Task CloseTask => _closeTcs.Task;
+
         #endregion
 
+        #region Public methods
+
         /// <summary>
-        /// Creates a new <see cref="Page"/>. If the target is not <c>"page"</c> or <c>"background_page"</c> returns <c>null</c>
+        /// If the target is not of type "page" or "background_page", returns null.
         /// </summary>
-        /// <returns>a task that returns a new <see cref="Page"/></returns>
-        public Task<Page> PageAsync()
-        {
-            if ((_targetInfo.Type == TargetType.Page || _targetInfo.Type == TargetType.BackgroundPage) && PageTask == null)
-            {
-                PageTask = CreatePageAsync();
-            }
-
-            return PageTask ?? Task.FromResult<Page>(null);
-        }
-
-        private async Task<Page> CreatePageAsync()
-        {
-            var session = await _sessionFactory(_targetInfo).ConfigureAwait(false);
-            return await Page.CreateAsync(session, this, Browser.IgnoreHTTPSErrors, Browser.DefaultViewport, Browser.ScreenshotTaskQueue).ConfigureAwait(false);
-        }
-
-        internal void TargetInfoChanged(TargetInfo targetInfo)
-        {
-            var previousUrl = _targetInfo.Url;
-            _targetInfo = targetInfo;
-
-            if (!IsInitialized && (_targetInfo.Type != TargetType.Page || _targetInfo.Url != string.Empty))
-            {
-                IsInitialized = true;
-                InitilizedTaskWrapper.TrySetResult(true);
-                return;
-            }
-
-            if (previousUrl != targetInfo.Url)
-            {
-                Browser.ChangeTarget(this);
-            }
-        }
+        public Task<Page> PageAsync() => _pageTask ?? (_pageTask = CreatePageAsync());
 
         /// <summary>
         /// Creates a Chrome Devtools Protocol session attached to the target.
         /// </summary>
         /// <returns>A task that returns a <see cref="CDPSession"/></returns>
-        public Task<CDPSession> CreateCDPSessionAsync() => Browser.Connection.CreateSessionAsync(_targetInfo);
+        public Task<CDPSession> CreateCDPSessionAsync() =>_sessionFactory(_targetInfo);
+
+        #endregion
+
+        #region Internal methods
+
+        internal void TargetInfoChanged(TargetInfo targetInfo) => _currentState.SetTargetInfo(this, targetInfo);
+
+        internal Task CloseAsync() => _currentState.CloseAsync(this);
+
+        internal void Destroyed() => _currentState.Destroyed(this);
+
+        #endregion
+
+        #region Private methods
+
+        /// <summary>
+        /// Creates a new <see cref="Page"/>. If the target is not <c>"page"</c> or <c>"background_page"</c> returns <c>null</c>
+        /// </summary>
+        /// <returns>a task that returns a new <see cref="Page"/></returns>
+        private async Task<Page> CreatePageAsync()
+        {
+            if (!await _initializeTcs.Task)
+            {
+                return null;
+            }
+
+            switch (Type)
+            {
+                case TargetType.Page:
+                case TargetType.BackgroundPage:
+                    var session = await _sessionFactory(_targetInfo)
+                        .ConfigureAwait(false);
+                    var browser = Browser;
+                    return await Page.CreateAsync(session, this, browser.IgnoreHTTPSErrors, browser.DefaultViewport, browser.ScreenshotTaskQueue)
+                        .ConfigureAwait(false);
+                default:
+                    return null;
+            }
+        }
+
+        private void SetTargetInfoCore(TargetInfo targetInfo, bool notifyBrowser)
+        {
+            notifyBrowser &= _targetInfo != null && _targetInfo.Url != targetInfo.Url;
+            _targetInfo = targetInfo;
+            if (notifyBrowser)
+            {
+                Browser.NotifyTargetChanged(this);
+            }
+        }
+
+        #endregion
+
+        #region State pattern
+
+        State IStateMachine<State>.CurrentState => _currentState;
+
+        bool IStateMachine<State>.TryEnter(State newState, State fromState)
+            => Interlocked.CompareExchange(ref _currentState, newState, fromState) == fromState;
+
+        internal abstract class State : AbstractState<Target, State>
+        {
+            public static readonly State Initial = new InitialState();
+            private static readonly InitializingState Initializing = new InitializingState();
+            private static readonly InitializedState Initialized = new InitializedState();
+            private static readonly ClosingState Closing = new ClosingState();
+            private static readonly ClosedState Closed = new ClosedState();
+
+            public virtual void SetTargetInfo(Target target, TargetInfo targetInfo) => throw InvalidOperation();
+            public virtual Task CloseAsync(Target target) => Closing.EnterFromAsync(target, this);
+            public virtual void Destroyed(Target target) => Closed.EnterFrom(target, this);
+
+            private class InitialState : State
+            {
+                public override void SetTargetInfo(Target target, TargetInfo targetInfo) =>
+                    Initializing.EnterFrom(target, this, targetInfo);
+            }
+
+            private class InitializingState : State
+            {
+                public void EnterFrom(Target target, State fromState, TargetInfo targetInfo)
+                {
+                    if (!TryEnter(target, fromState))
+                    {
+                        target._currentState.SetTargetInfo(target, targetInfo);
+                        return;
+                    }
+
+                    target.SetTargetInfoCore(targetInfo, false);
+                    if (targetInfo.Type != TargetType.Page || targetInfo.Url != string.Empty)
+                    {
+                        Initialized.EnterFrom(target, this);
+                    }
+                }
+
+                public override void SetTargetInfo(Target target, TargetInfo targetInfo) => EnterFrom(target, this, targetInfo);
+            }
+
+            private class InitializedState : State
+            {
+                public void EnterFrom(Target target, State fromState)
+                {
+                    if (TryEnter(target, fromState))
+                    {
+                        target.Browser.NotifyTargetCreated(target);
+                        target._initializeTcs.TrySetResult(true);
+                    }
+                }
+
+                public override void SetTargetInfo(Target target, TargetInfo targetInfo) => target.SetTargetInfoCore(targetInfo, true);
+
+                public override void Destroyed(Target target) => Closed.EnterFrom(target, this);
+            }
+
+            private class ClosingState : State
+            {
+                public async Task EnterFromAsync(Target target, State fromState)
+                {
+                    if (!TryEnter(target, fromState))
+                    {
+                        target._currentState.Destroyed(target);
+                    }
+
+                    try
+                    {
+                        if (await target.InitializeTask.ConfigureAwait(false))
+                        {
+                            await target.Browser.Connection.SendAsync("Target.closeTarget",
+                                    new TargetCloseTargetRequest { TargetId = target.TargetId })
+                                .ConfigureAwait(false);
+                            await target._closeTcs.Task
+                                .ConfigureAwait(false);
+                        }
+                        else
+                        {
+                            Closed.EnterFrom(target, this);
+                        }
+                    }
+                    catch (Exception)
+                    {
+                        Closed.EnterFrom(target, this);
+                        throw;
+                    }
+                }
+
+                public override void SetTargetInfo(Target target, TargetInfo targetInfo) => target.SetTargetInfoCore(targetInfo, target.IsInitialized);
+            }
+
+            private class ClosedState : State
+            {
+                public void EnterFrom(Target target, State fromState)
+                {
+                    if (!TryEnter(target, fromState))
+                    {
+                        target._currentState.Destroyed(target);
+                    }
+
+                    target._initializeTcs.TrySetResult(false);
+                    target._closeTcs.SetResult(true);
+
+                    _ = NotifyTargetDestroyedAsync(target);
+                }
+
+                public override Task CloseAsync(Target target) => Task.CompletedTask;
+
+                public override void Destroyed(Target target)
+                { }
+
+                private async Task NotifyTargetDestroyedAsync(Target target)
+                {
+                    if (await target.InitializeTask.ConfigureAwait(false))
+                    {
+                        // Only notify target destruction if target initialized successfully in the first place.
+                        target.Browser.NotifyTargetDestroyed(target);
+                    }
+                }
+            }
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
State management for the Target class is currently spread out over the Browser, Target and Page classes which makes it hard to verify correctness. Therefore it makes sense to localize all code that determines when certain Target operations can and/or should be performed in the Target class itself.