### PR TITLE
WebSocketTransport initialization, shutdown and extension

### DIFF
--- a/appveyor-fullframework.yml
+++ b/appveyor-fullframework.yml
@@ -16,7 +16,7 @@ only_commits:
     - appveyor-fullframework.yml
 before_build:
 - ps: >-
-    nuget.exe restore .\lib\PuppeteerSharp.AspNetFramework.sln
+    dotnet restore .\lib\PuppeteerSharp.AspNetFramework.sln
 
     New-SelfSignedCertificate -Subject "localhost" -FriendlyName "Puppeteer" -CertStoreLocation "cert:\CurrentUser\My"
 

--- a/lib/PuppeteerSharp.Tests/PuppeteerSharp.Tests.csproj
+++ b/lib/PuppeteerSharp.Tests/PuppeteerSharp.Tests.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="MicrosoftExtensions.Logging.Xunit" Version="1.0.0" />
-    <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
+    <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" Condition="'$(TargetFramework).StartsWith(`net4`)' == True" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-beta0005" />

--- a/lib/PuppeteerSharp.Tests/PuppeteerTests/PuppeteerConnectTests.cs
+++ b/lib/PuppeteerSharp.Tests/PuppeteerTests/PuppeteerConnectTests.cs
@@ -80,7 +80,6 @@ namespace PuppeteerSharp.Tests.PuppeteerTests
         }
 
         [Fact]
-        [Obsolete]
         public async Task ShouldSupportCustomWebSocket()
         {
             var customSocketCreated = false;

--- a/lib/PuppeteerSharp.Tests/PuppeteerTests/PuppeteerConnectTests.cs
+++ b/lib/PuppeteerSharp.Tests/PuppeteerTests/PuppeteerConnectTests.cs
@@ -1,5 +1,7 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
+using PuppeteerSharp.Transport;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -78,6 +80,7 @@ namespace PuppeteerSharp.Tests.PuppeteerTests
         }
 
         [Fact]
+        [Obsolete]
         public async Task ShouldSupportCustomWebSocket()
         {
             var customSocketCreated = false;
@@ -94,6 +97,26 @@ namespace PuppeteerSharp.Tests.PuppeteerTests
             using (await Puppeteer.ConnectAsync(options, TestConstants.LoggerFactory))
             {
                 Assert.True(customSocketCreated);
+            }
+        }
+
+        [Fact]
+        public async Task ShouldSupportCustomTransport()
+        {
+            var customTransportCreated = false;
+            var options = new ConnectOptions()
+            {
+                BrowserWSEndpoint = Browser.WebSocketEndpoint,
+                TransportFactory = (url, opt, cancellationToken) =>
+                {
+                    customTransportCreated = true;
+                    return WebSocketTransport.DefaultTransportFactory(url, opt, cancellationToken);
+                }
+            };
+
+            using (await Puppeteer.ConnectAsync(options, TestConstants.LoggerFactory))
+            {
+                Assert.True(customTransportCreated);
             }
         }
     }

--- a/lib/PuppeteerSharp.Tests/PuppeteerTests/PuppeteerConnectTests.cs
+++ b/lib/PuppeteerSharp.Tests/PuppeteerTests/PuppeteerConnectTests.cs
@@ -89,7 +89,7 @@ namespace PuppeteerSharp.Tests.PuppeteerTests
                 WebSocketFactory = (uri, socketOptions, cancellationToken) =>
                 {
                     customSocketCreated = true;
-                    return Connection.DefaultWebSocketFactory(uri, socketOptions, cancellationToken);
+                    return WebSocketTransport.DefaultWebSocketFactory(uri, socketOptions, cancellationToken);
                 }
             };
 

--- a/lib/PuppeteerSharp.Tests/PuppeteerTests/PuppeteerLaunchTests.cs
+++ b/lib/PuppeteerSharp.Tests/PuppeteerTests/PuppeteerLaunchTests.cs
@@ -402,7 +402,6 @@ namespace PuppeteerSharp.Tests.PuppeteerTests
         }
 
         [Fact]
-        [Obsolete]
         public async Task ShouldSupportCustomWebSocket()
         {
             var options = TestConstants.DefaultBrowserOptions();

--- a/lib/PuppeteerSharp.Tests/PuppeteerTests/PuppeteerLaunchTests.cs
+++ b/lib/PuppeteerSharp.Tests/PuppeteerTests/PuppeteerLaunchTests.cs
@@ -409,7 +409,7 @@ namespace PuppeteerSharp.Tests.PuppeteerTests
             options.WebSocketFactory = (uri, socketOptions, cancellationToken) =>
             {
                 customSocketCreated = true;
-                return Connection.DefaultWebSocketFactory(uri, socketOptions, cancellationToken);
+                return WebSocketTransport.DefaultWebSocketFactory(uri, socketOptions, cancellationToken);
             };
 
             using (await Puppeteer.LaunchAsync(options, TestConstants.LoggerFactory))

--- a/lib/PuppeteerSharp.Tests/PuppeteerTests/PuppeteerLaunchTests.cs
+++ b/lib/PuppeteerSharp.Tests/PuppeteerTests/PuppeteerLaunchTests.cs
@@ -1,13 +1,12 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net;
 using System.Runtime.InteropServices;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using PuppeteerSharp.Helpers;
+using PuppeteerSharp.Transport;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -403,6 +402,7 @@ namespace PuppeteerSharp.Tests.PuppeteerTests
         }
 
         [Fact]
+        [Obsolete]
         public async Task ShouldSupportCustomWebSocket()
         {
             var options = TestConstants.DefaultBrowserOptions();
@@ -416,6 +416,23 @@ namespace PuppeteerSharp.Tests.PuppeteerTests
             using (await Puppeteer.LaunchAsync(options, TestConstants.LoggerFactory))
             {
                 Assert.True(customSocketCreated);
+            }
+        }
+
+        [Fact]
+        public async Task ShouldSupportCustomTransport()
+        {
+            var customTransportCreated = false;
+            var options = TestConstants.DefaultBrowserOptions();
+            options.TransportFactory = (url, opt, cancellationToken) =>
+            {
+                customTransportCreated = true;
+                return WebSocketTransport.DefaultTransportFactory(url, opt, cancellationToken);
+            };
+
+            using (await Puppeteer.LaunchAsync(options, TestConstants.LoggerFactory))
+            {
+                Assert.True(customTransportCreated);
             }
         }
 

--- a/lib/PuppeteerSharp/ConnectOptions.cs
+++ b/lib/PuppeteerSharp/ConnectOptions.cs
@@ -1,12 +1,9 @@
 ﻿using System;
 using System.Net.WebSockets;
+using PuppeteerSharp.Transport;
 
 namespace PuppeteerSharp
 {
-    using System.Threading;
-    using System.Threading.Tasks;
-    using PuppeteerSharp.Transport;
-
     /// <summary>
     /// Options for connecting to an existing browser.
     /// </summary>
@@ -48,7 +45,7 @@ namespace PuppeteerSharp
         /// Optional factory for <see cref="WebSocket"/> implementations.
         /// If <see cref="Transport"/> is set this property will be ignored.
         /// </summary>
-        public Func<Uri, IConnectionOptions, CancellationToken, Task<WebSocket>> WebSocketFactory { get; set; }
+        public WebSocketFactory WebSocketFactory { get; set; }
 
         /// <summary>
         /// Gets or sets the default Viewport.
@@ -59,7 +56,14 @@ namespace PuppeteerSharp
         /// <summary>
         /// Optional connection transport.
         /// </summary>
+        [Obsolete("Use " + nameof(TransportFactory) + " instead")]
         public IConnectionTransport Transport { get; set; }
+
+        /// <summary>
+        /// Optional factory for <see cref="IConnectionTransport"/> implementations.
+        /// </summary>
+        public TransportFactory TransportFactory { get; set; }
+
         /// <summary>
         /// If not <see cref="Transport"/> is set this will be use to determine is the default <see cref="WebSocketTransport"/> will enqueue messages.
         /// </summary>

--- a/lib/PuppeteerSharp/IConnectionOptions.cs
+++ b/lib/PuppeteerSharp/IConnectionOptions.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Net.WebSockets;
-using System.Threading;
-using System.Threading.Tasks;
 using PuppeteerSharp.Transport;
 
 namespace PuppeteerSharp
@@ -26,12 +24,18 @@ namespace PuppeteerSharp
         /// Optional factory for <see cref="WebSocket"/> implementations.
         /// If <see cref="Transport"/> is set this property will be ignored.
         /// </summary>
-        Func<Uri, IConnectionOptions, CancellationToken, Task<WebSocket>> WebSocketFactory { get; set; }
+        WebSocketFactory WebSocketFactory { get; set; }
 
         /// <summary>
-        /// Optional connection transport.
+        /// Optional connection transport factory.
         /// </summary>
+        [Obsolete("Use " + nameof(TransportFactory) + " instead")]
         IConnectionTransport Transport { get; set; }
+
+        /// <summary>
+        /// Optional factory for <see cref="IConnectionTransport"/> implementations.
+        /// </summary>
+        TransportFactory TransportFactory { get; set; }
 
         /// <summary>
         /// If not <see cref="Transport"/> is set this will be use to determine is the default <see cref="WebSocketTransport"/> will enqueue messages.

--- a/lib/PuppeteerSharp/LaunchOptions.cs
+++ b/lib/PuppeteerSharp/LaunchOptions.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Net.WebSockets;
-using System.Threading;
-using System.Threading.Tasks;
 using PuppeteerSharp.Transport;
 
 namespace PuppeteerSharp
@@ -110,12 +108,18 @@ namespace PuppeteerSharp
         /// Optional factory for <see cref="WebSocket"/> implementations.
         /// If <see cref="Transport"/> is set this property will be ignored.
         /// </summary>
-        public Func<Uri, IConnectionOptions, CancellationToken, Task<WebSocket>> WebSocketFactory { get; set; }
+        public WebSocketFactory WebSocketFactory { get; set; }
 
         /// <summary>
         /// Optional connection transport.
         /// </summary>
+        [Obsolete("Use " + nameof(TransportFactory) + " instead")]
         public IConnectionTransport Transport { get; set; }
+
+        /// <summary>
+        /// Optional factory for <see cref="IConnectionTransport"/> implementations.
+        /// </summary>
+        public TransportFactory TransportFactory { get; set; }
 
         /// <summary>
         /// Gets or sets the default Viewport.

--- a/lib/PuppeteerSharp/Transport/IConnectionTransport.cs
+++ b/lib/PuppeteerSharp/Transport/IConnectionTransport.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Logging;
 
 namespace PuppeteerSharp.Transport
 {
@@ -10,14 +8,6 @@ namespace PuppeteerSharp.Transport
     /// </summary>
     public interface IConnectionTransport : IDisposable
     {
-        /// <summary>
-        /// Initialize the Transport
-        /// </summary>
-        /// <param name="url">Chromium URL</param>
-        /// <param name="connectionOptions">Connection options</param>
-        /// <param name="loggerFactory">Logger factory</param>
-        Task InitializeAsync(string url, IConnectionOptions connectionOptions, ILoggerFactory loggerFactory = null);
-
         /// <summary>
         /// Gets a value indicating whether this <see cref="PuppeteerSharp.Transport.IConnectionTransport"/> is closed.
         /// </summary>

--- a/lib/PuppeteerSharp/Transport/TransportFactory.cs
+++ b/lib/PuppeteerSharp/Transport/TransportFactory.cs
@@ -1,0 +1,15 @@
+﻿namespace PuppeteerSharp.Transport
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// Delegate for creation of <see cref="IConnectionTransport"/> instances.
+    /// </summary>
+    /// <param name="url">Chromium URL</param>
+    /// <param name="options">Connection options</param>
+    /// <param name="cancellationToken">A cancellation token</param>
+    /// <returns>A <see cref="Task{IConnectionTransport}"/> instance for the asynchronous socket create and connect operation.</returns>
+    public delegate Task<IConnectionTransport> TransportFactory(Uri url, IConnectionOptions options, CancellationToken cancellationToken);
+}

--- a/lib/PuppeteerSharp/Transport/TransportTaskScheduler.cs
+++ b/lib/PuppeteerSharp/Transport/TransportTaskScheduler.cs
@@ -1,0 +1,13 @@
+﻿namespace PuppeteerSharp.Transport
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// Delegate for scheduling of long-running transport tasks
+    /// </summary>
+    /// <param name="taskFactory">Delegate that creates the task to be scheduled.</param>
+    /// <param name="cancellationToken">Cancellation token for the task to be scheduled.</param>
+    public delegate void TransportTaskScheduler(Func<CancellationToken, Task> taskFactory, CancellationToken cancellationToken);
+}

--- a/lib/PuppeteerSharp/Transport/WebSocketFactory.cs
+++ b/lib/PuppeteerSharp/Transport/WebSocketFactory.cs
@@ -1,0 +1,16 @@
+﻿namespace PuppeteerSharp.Transport
+{
+    using System;
+    using System.Net.WebSockets;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// Delegate for creation of <see cref="WebSocket"/> instances.
+    /// </summary>
+    /// <param name="url">Chromium URL</param>
+    /// <param name="options">Connection options</param>
+    /// <param name="cancellationToken">A cancellation token</param>
+    /// <returns>A <see cref="Task{WebSocket}"/> instance for the asynchronous socket create and connect operation.</returns>
+    public delegate Task<WebSocket> WebSocketFactory(Uri url, IConnectionOptions options, CancellationToken cancellationToken);
+}

--- a/lib/PuppeteerSharp/Transport/WebSocketTransport.cs
+++ b/lib/PuppeteerSharp/Transport/WebSocketTransport.cs
@@ -3,7 +3,6 @@ using System.Net.WebSockets;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Logging;
 using PuppeteerSharp.Helpers;
 
 namespace PuppeteerSharp.Transport
@@ -13,12 +12,91 @@ namespace PuppeteerSharp.Transport
     /// </summary>
     public class WebSocketTransport : IConnectionTransport
     {
-        private WebSocket _client;
-        private bool _queueRequests;
-        private readonly TaskQueue _socketQueue;
-        private readonly bool _startReading;
+        #region Static fields
 
-        private CancellationTokenSource _readerCancellationSource { get; }
+        /// <summary>
+        /// Gets the default <see cref="WebSocketFactory"/>. This factory does not support Windows 7.
+        /// </summary>
+        public static readonly TransportFactory DefaultTransportFactory = CreateDefaultTransport;
+
+        /// <summary>
+        /// Gets the default <see cref="TransportFactory"/>
+        /// </summary>
+        public static readonly WebSocketFactory DefaultWebSocketFactory = CreateDefaultWebSocket;
+
+        /// <summary>
+        /// Gets the default <see cref="TransportTaskScheduler"/>
+        /// </summary>
+        public static readonly TransportTaskScheduler DefaultTransportScheduler = ScheduleTransportTask;
+
+        #endregion
+
+        #region Static methods
+
+        private static async Task<WebSocket> CreateDefaultWebSocket(Uri url, IConnectionOptions options, CancellationToken cancellationToken)
+        {
+            var result = new ClientWebSocket();
+            result.Options.KeepAliveInterval = TimeSpan.Zero;
+            await result.ConnectAsync(url, cancellationToken).ConfigureAwait(false);
+            return result;
+        }
+
+
+        private static async Task<IConnectionTransport> CreateDefaultTransport(Uri url, IConnectionOptions connectionOptions, CancellationToken cancellationToken)
+        {
+#pragma warning disable 618
+            // Backwards compatibility, but strongly discouraged!
+            if (connectionOptions.Transport != null)
+            {
+                return connectionOptions.Transport;
+            }
+#pragma warning restore 618
+            var webSocketFactory = connectionOptions.WebSocketFactory ?? DefaultWebSocketFactory;
+            var webSocket = await webSocketFactory(url, connectionOptions, cancellationToken);
+            return new WebSocketTransport(webSocket, DefaultTransportScheduler, connectionOptions.EnqueueTransportMessages);
+        }
+
+        private static void ScheduleTransportTask(Func<CancellationToken, Task> taskFactory, CancellationToken cancellationToken)
+            => Task.Factory.StartNew(() => taskFactory(cancellationToken), TaskCreationOptions.LongRunning);
+
+        #endregion
+
+        #region Instance fields
+
+        private readonly WebSocket _client;
+        private readonly bool _queueRequests;
+        private readonly TaskQueue _socketQueue = new TaskQueue();
+        private CancellationTokenSource _readerCancellationSource = new CancellationTokenSource();
+
+        #endregion
+
+        #region Constructor(s)
+
+        /// <summary>
+        /// Initialize the Transport
+        /// </summary>
+        /// <param name="client">The web socket</param>
+        /// <param name="scheduler">The scheduler to use for long-running tasks.</param>
+        /// <param name="queueRequests">Indicates whether requests should be queued.</param>
+        public WebSocketTransport(WebSocket client, TransportTaskScheduler scheduler, bool queueRequests)
+        {
+            if (client == null)
+            {
+                throw new ArgumentNullException(nameof(client));
+            }
+            if (scheduler == null)
+            {
+                throw new ArgumentNullException(nameof(scheduler));
+            }
+
+            _client = client;
+            _queueRequests = queueRequests;
+            scheduler(GetResponseAsync, _readerCancellationSource.Token);
+        }
+
+        #endregion
+
+        #region Properties
 
         /// <summary>
         /// Gets a value indicating whether this <see cref="PuppeteerSharp.Transport.IConnectionTransport"/> is closed.
@@ -33,40 +111,9 @@ namespace PuppeteerSharp.Transport
         /// </summary>
         public event EventHandler<MessageReceivedEventArgs> MessageReceived;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PuppeteerSharp.Transport.WebSocketTransport"/> class.
-        /// </summary>
-        /// <param name="startReading">If set to <c>true</c> the Transport will start reading as soon as it's initialized.</param>
-        public WebSocketTransport(bool startReading = true)
-        {
-            _startReading = startReading;
-            _socketQueue = new TaskQueue();
-            _readerCancellationSource = new CancellationTokenSource();
+        #endregion
 
-        }
-
-        /// <summary>
-        /// Initialize the Transport
-        /// </summary>
-        /// <param name="url">Chromium URL</param>
-        /// <param name="connectionOptions">Connection options</param>
-        /// <param name="loggerFactory">Logger factory</param>
-        public virtual async Task InitializeAsync(string url, IConnectionOptions connectionOptions, ILoggerFactory loggerFactory = null)
-        {
-            _client = await connectionOptions.WebSocketFactory(
-                new Uri(url),
-                connectionOptions,
-                default).ConfigureAwait(false);
-
-            _queueRequests = connectionOptions.EnqueueTransportMessages;
-
-            if (_startReading)
-            {
-                StartReading();
-            }
-        }
-
-        private void StartReading() => Task.Factory.StartNew(GetResponseAsync, TaskCreationOptions.LongRunning);
+        #region  Public methods
 
         /// <summary>
         /// Sends a message using the transport.
@@ -77,9 +124,9 @@ namespace PuppeteerSharp.Transport
         {
             var encoded = Encoding.UTF8.GetBytes(message);
             var buffer = new ArraySegment<byte>(encoded, 0, encoded.Length);
-            Task sendTask() => _client.SendAsync(buffer, WebSocketMessageType.Text, true, default);
+            Task SendCoreAsync() => _client.SendAsync(buffer, WebSocketMessageType.Text, true, default);
 
-            return _queueRequests ? _socketQueue.Enqueue(sendTask) : sendTask();
+            return _queueRequests ? _socketQueue.Enqueue(SendCoreAsync) : SendCoreAsync();
         }
 
         /// <summary>
@@ -87,32 +134,38 @@ namespace PuppeteerSharp.Transport
         /// </summary>
         public void StopReading()
         {
-            if (!IsClosed)
+            var readerCts = Interlocked.CompareExchange(ref _readerCancellationSource, null, _readerCancellationSource);
+            if (readerCts != null)
             {
-                // No need to cancel reading if no reading operation is in progress. Moreover,
-                // the _readerCancellationSource may already have been disposed, so cancelling
-                // it could cause an ObjectDisposedException.
-                _readerCancellationSource.Cancel();
+                // Asynchronous read operations may still be in progress, so cancel it first and then dispose
+                // the associated CancellationTokenSource.
+                readerCts.Cancel();
+                readerCts.Dispose();
             }
         }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            // Make sure any outstanding asynchronous read operation is cancelled.
+            StopReading();
+            _client?.Dispose();
+        }
+
+        #endregion
+
+        #region Private methods
 
         /// <summary>
         /// Starts listening the socket
         /// </summary>
         /// <returns>The start.</returns>
-        protected async Task<object> GetResponseAsync()
+        private async Task<object> GetResponseAsync(CancellationToken cancellationToken)
         {
             var buffer = new byte[2048];
 
-            //If it's not in the list we wait for it
-            while (true)
+            while (!IsClosed)
             {
-                if (IsClosed)
-                {
-                    OnClose("WebSocket is closed");
-                    return null;
-                }
-
                 var endOfMessage = false;
                 var response = new StringBuilder();
 
@@ -123,7 +176,7 @@ namespace PuppeteerSharp.Transport
                     {
                         result = await _client.ReceiveAsync(
                             new ArraySegment<byte>(buffer),
-                            _readerCancellationSource.Token).ConfigureAwait(false);
+                            cancellationToken).ConfigureAwait(false);
                     }
                     catch (OperationCanceledException)
                     {
@@ -150,19 +203,20 @@ namespace PuppeteerSharp.Transport
 
                 MessageReceived?.Invoke(this, new MessageReceivedEventArgs(response.ToString()));
             }
+
+            return null;
         }
 
         private void OnClose(string closeReason)
         {
-            Closed?.Invoke(this, new TransportClosedEventArgs(closeReason));
-            IsClosed = true;
+            if (!IsClosed)
+            {
+                IsClosed = true;
+                StopReading();
+                Closed?.Invoke(this, new TransportClosedEventArgs(closeReason));
+            }
         }
 
-        /// <inheritdoc/>
-        public void Dispose()
-        {
-            _client?.Dispose();
-            _readerCancellationSource?.Dispose();
-        }
+        #endregion
     }
 }

--- a/lib/PuppeteerSharp/Transport/WebSocketTransport.cs
+++ b/lib/PuppeteerSharp/Transport/WebSocketTransport.cs
@@ -44,13 +44,6 @@ namespace PuppeteerSharp.Transport
 
         private static async Task<IConnectionTransport> CreateDefaultTransport(Uri url, IConnectionOptions connectionOptions, CancellationToken cancellationToken)
         {
-#pragma warning disable 618
-            // Backwards compatibility, but strongly discouraged!
-            if (connectionOptions.Transport != null)
-            {
-                return connectionOptions.Transport;
-            }
-#pragma warning restore 618
             var webSocketFactory = connectionOptions.WebSocketFactory ?? DefaultWebSocketFactory;
             var webSocket = await webSocketFactory(url, connectionOptions, cancellationToken);
             return new WebSocketTransport(webSocket, DefaultTransportScheduler, connectionOptions.EnqueueTransportMessages);


### PR DESCRIPTION
While testing the latest commits I no longer experienced hangs, but the debugger did break on some exceptions that are not really necessary in the `WebSocketTransport`. This pull request puts some additional belts and braces around the starting, stopping and cancelling of read operations.