### PR TITLE
Change default timeout back to 30000ms

### DIFF
--- a/lib/PuppeteerSharp/TimeoutSettings.cs
+++ b/lib/PuppeteerSharp/TimeoutSettings.cs
@@ -10,6 +10,6 @@
             set => _defaultNavigationTimeout = value;
         }
 
-        public int Timeout { get; set; } = 3000;
+        public int Timeout { get; set; } = 30000;
     }
 }


### PR DESCRIPTION
It looks like the default timeout was changed with this commit: https://github.com/kblok/puppeteer-sharp/commit/2e59b1eef049836b54767f09c72d345ac0f84227

I figured this was a typo because the comments seem to imply that it should still be 30 seconds. 

This is my first pull request, so let me know if I did something wrong.