### PR TITLE
Isolating the Posix code so it doesn't get loaded in net471.

### DIFF
--- a/lib/PuppeteerSharp.Tests/test.runsettings
+++ b/lib/PuppeteerSharp.Tests/test.runsettings
@@ -2,6 +2,6 @@
 <RunSettings>  
   <!-- Configurations that affect the Test Framework -->  
   <RunConfiguration>
-    <TestSessionTimeout>480000</TestSessionTimeout>
+    <TestSessionTimeout>900000</TestSessionTimeout>
   </RunConfiguration>
 </RunSettings>

--- a/lib/PuppeteerSharp/BrowserFetcher.cs
+++ b/lib/PuppeteerSharp/BrowserFetcher.cs
@@ -204,7 +204,12 @@ namespace PuppeteerSharp
 
             if (revisionInfo != null && GetCurrentPlatform() == Platform.Linux)
             {
-                LinuxPermissionsSetter.SetExecutableFilePermissions(revisionInfo.ExecutablePath);
+                void SetPermissions(string fullPath)
+                {
+                    LinuxPermissionsSetter.SetExecutableFilePermissions(fullPath);
+                }
+
+                SetPermissions(revisionInfo.ExecutablePath);
             }
             return revisionInfo;
         }

--- a/lib/PuppeteerSharp/BrowserFetcher.cs
+++ b/lib/PuppeteerSharp/BrowserFetcher.cs
@@ -204,10 +204,7 @@ namespace PuppeteerSharp
 
             if (revisionInfo != null && GetCurrentPlatform() == Platform.Linux)
             {
-                void SetPermissions(string fullPath)
-                {
-                    LinuxPermissionsSetter.SetExecutableFilePermissions(fullPath);
-                }
+                void SetPermissions(string fullPath) => LinuxPermissionsSetter.SetExecutableFilePermissions(fullPath);
 
                 SetPermissions(revisionInfo.ExecutablePath);
             }


### PR DESCRIPTION
Fixes https://github.com/kblok/puppeteer-sharp/issues/1050

As the code path is now called from a local function, the static fields of LinuxPermissionsSetter are not loaded by the .net until the local function is called. What was happening, is when ```DownloadAsync``` is invoked, it loads the ```LinuxPermissionsSetter``` class, thus loading the static field ```ExecutableFilePermissions``` which then loads the ```FileAccessPermissions``` enum from the Posix lib.