### PR TITLE
Paper Format Accessibility Changes

### DIFF
--- a/lib/PuppeteerSharp/Media/PaperFormat.cs
+++ b/lib/PuppeteerSharp/Media/PaperFormat.cs
@@ -6,7 +6,7 @@ namespace PuppeteerSharp.Media
     /// <summary>
     /// Paper format.
     /// </summary>
-    /// <seealso cref="PdfOptions.Format" />
+    /// <seealso cref="PdfOptions.Format"/>
     public class PaperFormat : IEquatable<PaperFormat>
     {
         /// <summary>

--- a/lib/PuppeteerSharp/Media/PaperFormat.cs
+++ b/lib/PuppeteerSharp/Media/PaperFormat.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 namespace PuppeteerSharp.Media
@@ -6,7 +6,7 @@ namespace PuppeteerSharp.Media
     /// <summary>
     /// Paper format.
     /// </summary>
-    /// <seealso cref="PdfOptions.Format"/>
+    /// <seealso cref="P:PuppeteerSharp.PdfOptions.Format" />
     public class PaperFormat : IEquatable<PaperFormat>
     {
         /// <summary>

--- a/lib/PuppeteerSharp/Media/PaperFormat.cs
+++ b/lib/PuppeteerSharp/Media/PaperFormat.cs
@@ -24,13 +24,13 @@ namespace PuppeteerSharp.Media
         /// Page width in inches
         /// </summary>
         /// <value>The width.</value>
-        public decimal Width { get; set; }
+        public readonly decimal Width;
 
         /// <summary>
         /// Page height in inches
         /// </summary>
         /// <value>The Height.</value>
-        public decimal Height { get; set; }
+        public readonly decimal Height;
 
         /// <summary>
         /// Letter.

--- a/lib/PuppeteerSharp/Media/PaperFormat.cs
+++ b/lib/PuppeteerSharp/Media/PaperFormat.cs
@@ -33,47 +33,57 @@ namespace PuppeteerSharp.Media
         public readonly decimal Height;
 
         /// <summary>
-        /// Letter.
+        /// Letter: 8.5 inches x 11 inches.
         /// </summary>
         public static readonly PaperFormat Letter = new PaperFormat(8.5m, 11);
+        
         /// <summary>
-        /// Legal.
+        /// Legal: 8.5 inches by 14 inches.
         /// </summary>
         public static readonly PaperFormat Legal = new PaperFormat(8.5m, 14);
+        
         /// <summary>
-        /// Tabloid.
+        /// Tabloid: 11 inches by 17 inches.
         /// </summary>
         public static readonly PaperFormat Tabloid = new PaperFormat(11, 17);
+        
         /// <summary>
-        /// Ledger.
+        /// Ledger: 17 inches by 11 inches.
         /// </summary>
         public static readonly PaperFormat Ledger = new PaperFormat(17, 11);
+        
         /// <summary>
-        /// A0.
+        /// A0: 33.1 inches by 46.8 inches.
         /// </summary>
         public static readonly PaperFormat A0 = new PaperFormat(33.1m, 46.8m);
+        
         /// <summary>
-        /// A1.
+        /// A1: 23.4 inches by 33.1 inches
         /// </summary>
         public static readonly PaperFormat A1 = new PaperFormat(23.4m, 33.1m);
+        
         /// <summary>
-        /// A2.
+        /// A2: 16.5 inches by 23.4 inches
         /// </summary>
         public static readonly PaperFormat A2 = new PaperFormat(16.5m, 23.4m);
+        
         /// <summary>
-        /// A3.
+        /// A3: 11.7 inches by 16.5 inches
         /// </summary>
         public static readonly PaperFormat A3 = new PaperFormat(11.7m, 16.5m);
+        
         /// <summary>
-        /// A4.
+        /// A4: 8.27 inches by 11.7 inches
         /// </summary>
         public static readonly PaperFormat A4 = new PaperFormat(8.27m, 11.7m);
+        
         /// <summary>
-        /// A5.
+        /// A5: 5.83 inches by 8.27 inches
         /// </summary>
         public static readonly PaperFormat A5 = new PaperFormat(5.83m, 8.27m);
+        
         /// <summary>
-        /// A6.
+        /// A6: 4.13 inches by 5.83 inches
         /// </summary>
         public static readonly PaperFormat A6 = new PaperFormat(4.13m, 5.83m);
 

--- a/lib/PuppeteerSharp/Media/PaperFormat.cs
+++ b/lib/PuppeteerSharp/Media/PaperFormat.cs
@@ -6,7 +6,7 @@ namespace PuppeteerSharp.Media
     /// <summary>
     /// Paper format.
     /// </summary>
-    /// <seealso cref="P:PuppeteerSharp.PdfOptions.Format" />
+    /// <seealso cref="PdfOptions.Format" />
     public class PaperFormat : IEquatable<PaperFormat>
     {
         /// <summary>
@@ -24,68 +24,68 @@ namespace PuppeteerSharp.Media
         /// Page width in inches
         /// </summary>
         /// <value>The width.</value>
-        public readonly decimal Width;
+        public decimal Width { get; set; }
 
         /// <summary>
         /// Page height in inches
         /// </summary>
         /// <value>The Height.</value>
-        public readonly decimal Height;
+        public decimal Height { get; set; }
 
         /// <summary>
         /// Letter: 8.5 inches x 11 inches.
         /// </summary>
-        public static readonly PaperFormat Letter = new PaperFormat(8.5m, 11);
+        public static PaperFormat Letter => new PaperFormat(8.5m, 11);
         
         /// <summary>
         /// Legal: 8.5 inches by 14 inches.
         /// </summary>
-        public static readonly PaperFormat Legal = new PaperFormat(8.5m, 14);
+        public static PaperFormat Legal => new PaperFormat(8.5m, 14);
         
         /// <summary>
         /// Tabloid: 11 inches by 17 inches.
         /// </summary>
-        public static readonly PaperFormat Tabloid = new PaperFormat(11, 17);
+        public static PaperFormat Tabloid => new PaperFormat(11, 17);
         
         /// <summary>
         /// Ledger: 17 inches by 11 inches.
         /// </summary>
-        public static readonly PaperFormat Ledger = new PaperFormat(17, 11);
+        public static PaperFormat Ledger => new PaperFormat(17, 11);
         
         /// <summary>
         /// A0: 33.1 inches by 46.8 inches.
         /// </summary>
-        public static readonly PaperFormat A0 = new PaperFormat(33.1m, 46.8m);
+        public static PaperFormat A0 => new PaperFormat(33.1m, 46.8m);
         
         /// <summary>
         /// A1: 23.4 inches by 33.1 inches
         /// </summary>
-        public static readonly PaperFormat A1 = new PaperFormat(23.4m, 33.1m);
+        public static PaperFormat A1 => new PaperFormat(23.4m, 33.1m);
         
         /// <summary>
         /// A2: 16.5 inches by 23.4 inches
         /// </summary>
-        public static readonly PaperFormat A2 = new PaperFormat(16.5m, 23.4m);
+        public static PaperFormat A2 => new PaperFormat(16.5m, 23.4m);
         
         /// <summary>
         /// A3: 11.7 inches by 16.5 inches
         /// </summary>
-        public static readonly PaperFormat A3 = new PaperFormat(11.7m, 16.5m);
+        public static PaperFormat A3 => new PaperFormat(11.7m, 16.5m);
         
         /// <summary>
         /// A4: 8.27 inches by 11.7 inches
         /// </summary>
-        public static readonly PaperFormat A4 = new PaperFormat(8.27m, 11.7m);
+        public static PaperFormat A4 => new PaperFormat(8.27m, 11.7m);
         
         /// <summary>
         /// A5: 5.83 inches by 8.27 inches
         /// </summary>
-        public static readonly PaperFormat A5 = new PaperFormat(5.83m, 8.27m);
+        public static PaperFormat A5 => new PaperFormat(5.83m, 8.27m);
         
         /// <summary>
         /// A6: 4.13 inches by 5.83 inches
         /// </summary>
-        public static readonly PaperFormat A6 = new PaperFormat(4.13m, 5.83m);
+        public static PaperFormat A6 => new PaperFormat(4.13m, 5.83m);
 
         /// <inheritdoc/>
         public override bool Equals(object obj)

--- a/lib/PuppeteerSharp/Media/PaperFormat.cs
+++ b/lib/PuppeteerSharp/Media/PaperFormat.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 namespace PuppeteerSharp.Media
@@ -9,8 +9,12 @@ namespace PuppeteerSharp.Media
     /// <seealso cref="PdfOptions.Format"/>
     public class PaperFormat : IEquatable<PaperFormat>
     {
-        private PaperFormat() { }
-        private PaperFormat(decimal width, decimal height)
+        /// <summary>
+        /// Page width and height in inches.
+        /// </summary>
+        /// <param name="width">Page width in inches</param>
+        /// <param name="height">Page height in inches</param>
+        public PaperFormat(decimal width, decimal height)
         {
             Width = width;
             Height = height;


### PR DESCRIPTION
- Make a public constructor for `PaperFormat`
- Make `Height` and `Width` readonly properties.

closes #1061