### PR TITLE
Microsoft Edge Friendly tests

### DIFF
--- a/lib/PuppeteerSharp.Tests/ChromiumSpecificTests/PageTests.cs
+++ b/lib/PuppeteerSharp.Tests/ChromiumSpecificTests/PageTests.cs
@@ -34,7 +34,7 @@ namespace PuppeteerSharp.Tests.ChromiumSpecificTests
 
             await Page.GoToAsync(TestConstants.ServerUrl + "/intervention");
 
-            Assert.Contains("www.chromestatus.com", interventionHeader);
+            Assert.Contains("feature/5718547946799104", interventionHeader);
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/NetworkTests/ResponseTextTests.cs
+++ b/lib/PuppeteerSharp.Tests/NetworkTests/ResponseTextTests.cs
@@ -19,7 +19,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
         public async Task ShouldWork()
         {
             var response = await Page.GoToAsync(TestConstants.ServerUrl + "/simple.json");
-            Assert.Equal("{\"foo\": \"bar\"}\n", await response.TextAsync());
+            Assert.Equal("{\"foo\": \"bar\"}", (await response.TextAsync()).Trim());
         }
 
         [Fact]
@@ -28,7 +28,7 @@ namespace PuppeteerSharp.Tests.NetworkTests
             Server.EnableGzip("/simple.json");
             var response = await Page.GoToAsync(TestConstants.ServerUrl + "/simple.json");
             Assert.Equal("gzip", response.Headers["Content-Encoding"]);
-            Assert.Equal("{\"foo\": \"bar\"}\n", await response.TextAsync());
+            Assert.Equal("{\"foo\": \"bar\"}", (await response.TextAsync()).Trim());
         }
 
         [Fact]

--- a/lib/PuppeteerSharp.Tests/PuppeteerTests/PuppeteerLaunchTests.cs
+++ b/lib/PuppeteerSharp.Tests/PuppeteerTests/PuppeteerLaunchTests.cs
@@ -240,14 +240,9 @@ namespace PuppeteerSharp.Tests.PuppeteerTests
             var options = TestConstants.DefaultBrowserOptions();
             options.IgnoreDefaultArgs = true;
             using (var browser = await Puppeteer.LaunchAsync(options, TestConstants.LoggerFactory))
+            using (var page = await browser.NewPageAsync())
             {
-                //Puppeteer's code checks for a Single page.
-                //As "Microsoft Edge" opens two pages, checking for "NotEmpty" would help us run this test against both browsers.
-                Assert.NotEmpty(await browser.PagesAsync());
-                using (var page = await browser.NewPageAsync())
-                {
-                    Assert.Equal(121, await page.EvaluateExpressionAsync<int>("11 * 11"));
-                }
+                Assert.Equal(121, await page.EvaluateExpressionAsync<int>("11 * 11"));
             }
         }
 

--- a/lib/PuppeteerSharp.Tests/PuppeteerTests/PuppeteerLaunchTests.cs
+++ b/lib/PuppeteerSharp.Tests/PuppeteerTests/PuppeteerLaunchTests.cs
@@ -241,7 +241,7 @@ namespace PuppeteerSharp.Tests.PuppeteerTests
             options.IgnoreDefaultArgs = true;
             using (var browser = await Puppeteer.LaunchAsync(options, TestConstants.LoggerFactory))
             {
-                Assert.Single(await browser.PagesAsync());
+                Assert.NotEmpty(await browser.PagesAsync());
                 using (var page = await browser.NewPageAsync())
                 {
                     Assert.Equal(121, await page.EvaluateExpressionAsync<int>("11 * 11"));

--- a/lib/PuppeteerSharp.Tests/PuppeteerTests/PuppeteerLaunchTests.cs
+++ b/lib/PuppeteerSharp.Tests/PuppeteerTests/PuppeteerLaunchTests.cs
@@ -241,6 +241,8 @@ namespace PuppeteerSharp.Tests.PuppeteerTests
             options.IgnoreDefaultArgs = true;
             using (var browser = await Puppeteer.LaunchAsync(options, TestConstants.LoggerFactory))
             {
+                //Puppeteer's code checks for a Single page.
+                //As "Microsoft Edge" opens two pages, checking for "NotEmpty" would help us run this test against both browsers.
                 Assert.NotEmpty(await browser.PagesAsync());
                 using (var page = await browser.NewPageAsync())
                 {


### PR DESCRIPTION
We made some minor changes to our tests so they run with Microsoft Edge:
 * Intervention header has the URL https://to-be-replaced.invalid/feature/5718547946799104 instead of https://www.chromestatus.com/feature/5718547946799104. We are changing the "Contains" part
 * We are removing some new lines and using Trim to compare TextAsync
 * Edge launches two pages with default arguments. We are going to check that  the pages array is not empty.