### PR TITLE
Evaluate expressions on new document support

### DIFF
--- a/lib/PuppeteerSharp.Tests/FrameTests/WaitForFunctionTests.cs
+++ b/lib/PuppeteerSharp.Tests/FrameTests/WaitForFunctionTests.cs
@@ -15,7 +15,7 @@ namespace PuppeteerSharp.Tests.FrameTests
         [Fact]
         public async Task ShouldWorkWhenResolvedRightBeforeExecutionContextDisposal()
         {
-            await Page.EvaluateOnNewDocumentAsync("() => window.__RELOADED = true");
+            await Page.EvaluateFunctionOnNewDocumentAsync("() => window.__RELOADED = true");
             await Page.WaitForFunctionAsync(@"() =>
             {
                 if (!window.__RELOADED)

--- a/lib/PuppeteerSharp.Tests/PageTests/EvaluateOnNewDocumentTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/EvaluateOnNewDocumentTests.cs
@@ -18,7 +18,7 @@ namespace PuppeteerSharp.Tests.PageTests
         [Fact]
         public async Task ShouldEvaluateBeforeAnythingElseOnThePage()
         {
-            await Page.EvaluateOnNewDocumentAsync(@"function(){
+            await Page.EvaluateFunctionOnNewDocumentAsync(@"function(){
                 window.injected = 123;
             }");
             await Page.GoToAsync(TestConstants.ServerUrl + "/tamperable.html");
@@ -29,7 +29,7 @@ namespace PuppeteerSharp.Tests.PageTests
         public async Task ShouldWorkWithCSP()
         {
             Server.SetCSP("/empty.html", "script-src " + TestConstants.ServerUrl);
-            await Page.EvaluateOnNewDocumentAsync(@"function(){
+            await Page.EvaluateFunctionOnNewDocumentAsync(@"function(){
                 window.injected = 123;
             }");
             await Page.GoToAsync(TestConstants.EmptyPage);
@@ -41,6 +41,14 @@ namespace PuppeteerSharp.Tests.PageTests
                 Content = "window.e = 10;"
             }).ContinueWith(_ => Task.CompletedTask);
             Assert.Null(await Page.EvaluateExpressionAsync("window.e"));
+        }
+
+        [Fact]
+        public async Task ShouldWorkWithExpressions()
+        {
+            await Page.EvaluateExpressionOnNewDocumentAsync("window.injected = 123;");
+            await Page.GoToAsync(TestConstants.ServerUrl + "/tamperable.html");
+            Assert.Equal(123, await Page.EvaluateExpressionAsync<int>("window.result"));
         }
     }
 }

--- a/lib/PuppeteerSharp.Tests/PageTests/ExposeFunctionTests.cs
+++ b/lib/PuppeteerSharp.Tests/PageTests/ExposeFunctionTests.cs
@@ -44,7 +44,7 @@ namespace PuppeteerSharp.Tests.PageTests
         {
             var called = false;
             await Page.ExposeFunctionAsync("woof", () => called = true);
-            await Page.EvaluateOnNewDocumentAsync("() => woof()");
+            await Page.EvaluateFunctionOnNewDocumentAsync("() => woof()");
             await Page.ReloadAsync();
             Assert.True(called);
         }


### PR DESCRIPTION
We are spliting EvaluateOnNewDocumentAsync into two methods. EvaluateFunctionOnNewDocumentAsync and EvaluateExpresionOnNewDocumentAsync.

closes #1183