### PR TITLE
Adding support for .net framework on Win 7 and Server 2008

### DIFF
--- a/lib/PuppeteerSharp/PuppeteerSharp.csproj
+++ b/lib/PuppeteerSharp/PuppeteerSharp.csproj
@@ -39,6 +39,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="System.Net.Http" Version="4.3.3" />
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.0.2" />
+    <PackageReference Include="System.Net.WebSockets.Client.Managed" Version="1.0.22" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.1" />
   </ItemGroup>
 </Project>

--- a/lib/PuppeteerSharp/Transport/WebSocketTransport.cs
+++ b/lib/PuppeteerSharp/Transport/WebSocketTransport.cs
@@ -50,7 +50,6 @@ namespace PuppeteerSharp.Transport
             return result;
         }
 
-
         private static async Task<IConnectionTransport> CreateDefaultTransport(Uri url, IConnectionOptions connectionOptions, CancellationToken cancellationToken)
         {
             var webSocketFactory = connectionOptions.WebSocketFactory ?? DefaultWebSocketFactory;

--- a/lib/PuppeteerSharp/Transport/WebSocketTransport.cs
+++ b/lib/PuppeteerSharp/Transport/WebSocketTransport.cs
@@ -4,6 +4,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using PuppeteerSharp.Helpers;
+using Managed = System.Net.WebSockets.Managed;
 
 namespace PuppeteerSharp.Transport
 {
@@ -35,8 +36,18 @@ namespace PuppeteerSharp.Transport
 
         private static async Task<WebSocket> CreateDefaultWebSocket(Uri url, IConnectionOptions options, CancellationToken cancellationToken)
         {
-            var result = new ClientWebSocket();
-            result.Options.KeepAliveInterval = TimeSpan.Zero;
+            var result = SystemClientWebSocket.CreateClientWebSocket();
+
+            switch (result)
+            {
+                case ClientWebSocket cws:
+                    cws.Options.KeepAliveInterval = TimeSpan.Zero;
+                    break;
+                case Managed.ClientWebSocket mcws:
+                    mcws.Options.KeepAliveInterval = TimeSpan.Zero;
+                    break;
+            }
+            
             await result.ConnectAsync(url, cancellationToken).ConfigureAwait(false);
             return result;
         }

--- a/lib/PuppeteerSharp/Transport/WebSocketTransport.cs
+++ b/lib/PuppeteerSharp/Transport/WebSocketTransport.cs
@@ -37,7 +37,6 @@ namespace PuppeteerSharp.Transport
         private static async Task<WebSocket> CreateDefaultWebSocket(Uri url, IConnectionOptions options, CancellationToken cancellationToken)
         {
             var result = SystemClientWebSocket.CreateClientWebSocket();
-
             switch (result)
             {
                 case ClientWebSocket cws:
@@ -47,7 +46,6 @@ namespace PuppeteerSharp.Transport
                     mcws.Options.KeepAliveInterval = TimeSpan.Zero;
                     break;
             }
-            
             await result.ConnectAsync(url, cancellationToken).ConfigureAwait(false);
             return result;
         }


### PR DESCRIPTION
- Adds dependency on System.Net.WebSockets.Client.Managed.
- If on a platform that is missing ClientWebSocket, uses Managed version.