### PR TITLE
Clarify frame/page.GotAsync()'s handling of HTTP error statuses

### DIFF
--- a/lib/PuppeteerSharp/Frame.cs
+++ b/lib/PuppeteerSharp/Frame.cs
@@ -101,7 +101,23 @@ namespace PuppeteerSharp
 
         /// <summary>
         /// Navigates to an url
-        /// </summary>        
+        /// </summary>
+        /// <remarks>
+        /// <see cref="GoToAsync(string, int?, WaitUntilNavigation[])"/> will throw an error if:
+        /// - there's an SSL error (e.g. in case of self-signed certificates).
+        /// - target URL is invalid.
+        /// - the `timeout` is exceeded during navigation.
+        /// - the remote server does not respond or is unreachable.
+        /// - the main resource failed to load.
+        /// 
+        /// <see cref="GoToAsync(string, int?, WaitUntilNavigation[])"/> will not throw an error when any valid HTTP status code is returned by the remote server, 
+        /// including 404 "Not Found" and 500 "Internal Server Error".  The status code for such responses can be retrieved by calling <see cref="Response.Status"/>
+        /// 
+        /// > **NOTE** <see cref="GoToAsync(string, int?, WaitUntilNavigation[])"/> either throws an error or returns a main resource response. 
+        /// The only exceptions are navigation to `about:blank` or navigation to the same URL with a different hash, which would succeed and return `null`.
+        /// 
+        /// > **NOTE** Headless mode doesn't support navigation to a PDF document. See the <see fref="https://bugs.chromium.org/p/chromium/issues/detail?id=761295">upstream issue</see>.
+        /// </remarks>
         /// <param name="url">URL to navigate page to. The url should include scheme, e.g. https://.</param>
         /// <param name="options">Navigation parameters.</param>
         /// <returns>Task which resolves to the main resource response. In case of multiple redirects, the navigation will resolve with the response of the last redirect.</returns>

--- a/lib/PuppeteerSharp/Page.cs
+++ b/lib/PuppeteerSharp/Page.cs
@@ -789,7 +789,25 @@ namespace PuppeteerSharp
 
         /// <summary>
         /// Navigates to an url
-        /// </summary>        
+        /// </summary>
+        /// <remarks>
+        /// <see cref="GoToAsync(string, int?, WaitUntilNavigation[])"/> will throw an error if:
+        /// - there's an SSL error (e.g. in case of self-signed certificates).
+        /// - target URL is invalid.
+        /// - the `timeout` is exceeded during navigation.
+        /// - the remote server does not respond or is unreachable.
+        /// - the main resource failed to load.
+        /// 
+        /// <see cref="GoToAsync(string, int?, WaitUntilNavigation[])"/> will not throw an error when any valid HTTP status code is returned by the remote server, 
+        /// including 404 "Not Found" and 500 "Internal Server Error".  The status code for such responses can be retrieved by calling <see cref="Response.Status"/>
+        /// 
+        /// > **NOTE** <see cref="GoToAsync(string, int?, WaitUntilNavigation[])"/> either throws an error or returns a main resource response. 
+        /// The only exceptions are navigation to `about:blank` or navigation to the same URL with a different hash, which would succeed and return `null`.
+        /// 
+        /// > **NOTE** Headless mode doesn't support navigation to a PDF document. See the <see fref="https://bugs.chromium.org/p/chromium/issues/detail?id=761295">upstream issue</see>.
+        /// 
+        /// Shortcut for <seealso cref="Frame.GoToAsync(string, int?, WaitUntilNavigation[])"/>
+        /// </remarks>
         /// <param name="url">URL to navigate page to. The url should include scheme, e.g. https://.</param>
         /// <param name="options">Navigation parameters.</param>
         /// <returns>Task which resolves to the main resource response. In case of multiple redirects, the navigation will resolve with the response of the last redirect.</returns>


### PR DESCRIPTION
closes #1171