### PR TITLE
Updated to work with VS2019 and .NET Core 3.1

### DIFF
--- a/demos/PuppeteerSharpPdfDemo/PuppeteerSharpPdfDemo.csproj
+++ b/demos/PuppeteerSharpPdfDemo/PuppeteerSharpPdfDemo.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="PuppeteerSharp" Version="1.0.1" />
+    <PackageReference Include="PuppeteerSharp" Version="2.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Pretty self-explanatory. I'm using VS2019 and .NET Core 3.1 for my project and needed to ensure puppeteersharp would work with it. 